### PR TITLE
Implemented: POC of loglevel and loglevel-plugin-remote library for basic logging on browser console. (#21uxamh)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "core-js": "^3.6.5",
     "file-saver": "^2.0.5",
     "http-status-codes": "^2.1.4",
+    "loglevel": "^1.8.0",
     "luxon": "^2.3.0",
     "mitt": "^2.1.0",
     "vue": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "file-saver": "^2.0.5",
     "http-status-codes": "^2.1.4",
     "loglevel": "^1.8.0",
-    "loglevel-plugin-remote": "^0.6.8",
+    "loglevel-plugin-remote": "git+https://github.com/k2maan/loglevel-plugin-remote.git",
     "luxon": "^2.3.0",
     "mitt": "^2.1.0",
     "vue": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "file-saver": "^2.0.5",
     "http-status-codes": "^2.1.4",
     "loglevel": "^1.8.0",
+    "loglevel-plugin-remote": "^0.6.8",
     "luxon": "^2.3.0",
     "mitt": "^2.1.0",
     "vue": "^3.2.26",
@@ -54,9 +55,9 @@
     "eslint": "^7.32.0",
     "eslint-plugin-vue": "^8.0.3",
     "jest": "^27.1.0",
-    "ts-jest": "^27.0.4",
-    "typescript": "~4.1.5",
     "papaparse": "^5.3.1",
+    "ts-jest": "^27.0.4",
+    "typescript": "^4.1.6",
     "vue-cli-plugin-i18n": "^1.0.1",
     "vue-jest": "^5.0.0-0"
   }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -45,6 +45,7 @@ import { codeWorkingOutline, ellipsisVertical, personCircleOutline, storefrontOu
 import { mapGetters, useStore } from 'vuex';
 import { useRouter } from 'vue-router';
 import TimeZoneModal from '@/views/TimezoneModal.vue';
+import log from 'loglevel';
 
 export default defineComponent({
   name: 'Settings',
@@ -75,6 +76,10 @@ export default defineComponent({
         if (fac.facilityId == facility['detail'].value) {
           this.store.dispatch('user/setFacility', {'facility': fac});
           console.log(fac);
+          log.info('this is an info log')
+          log.trace('this is a trace log')
+          log.warn('this is a warning log')
+          log.error('err! this is an error log')
         }
       })
     },

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -46,6 +46,7 @@ import { mapGetters, useStore } from 'vuex';
 import { useRouter } from 'vue-router';
 import TimeZoneModal from '@/views/TimezoneModal.vue';
 import log from 'loglevel';
+import remote from 'loglevel-plugin-remote'
 
 export default defineComponent({
   name: 'Settings',
@@ -76,6 +77,7 @@ export default defineComponent({
         if (fac.facilityId == facility['detail'].value) {
           this.store.dispatch('user/setFacility', {'facility': fac});
           console.log(fac);
+          remote.apply(log, {});
           log.info('this is an info log')
           log.trace('this is a trace log')
           log.warn('this is a warning log')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,12 @@
       "dom",
       "dom.iterable",
       "scripthost"
-    ]
+    ],
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "declarationMap": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
## Related to #63 

## Description 
[Loglevel](https://github.com/pimterry/loglevel) is a client-specific logging library. I've implemented the basic usage, using info, trace, warn, and error levels.

## Screenshot
![Screenshot from 2022-10-13 16-11-10](https://user-images.githubusercontent.com/59442907/195576087-f3ff8cdf-ecb7-4162-a713-6a7047811cf4.png)
