### PR TITLE
Implemented: POC of vue-logger-plugin (#21uxamh-vue-logger-plugin)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "core-js": "^3.6.5",
     "file-saver": "^2.0.5",
     "http-status-codes": "^2.1.4",
+    "loglevel": "^1.8.0",
     "luxon": "^2.3.0",
     "mitt": "^2.1.0",
     "vue": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,11 @@
     "core-js": "^3.6.5",
     "file-saver": "^2.0.5",
     "http-status-codes": "^2.1.4",
-    "loglevel": "^1.8.0",
-    "loglevel-plugin-remote": "git+https://github.com/k2maan/loglevel-plugin-remote.git",
     "luxon": "^2.3.0",
     "mitt": "^2.1.0",
     "vue": "^3.2.26",
     "vue-i18n": "^9.0.0",
+    "vue-logger-plugin": "^2.2.3",
     "vue-router": "^4.0.12",
     "vuex": "^4.0.1",
     "vuex-persistedstate": "^4.0.0-beta.3"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "file-saver": "^2.0.5",
     "http-status-codes": "^2.1.4",
     "loglevel": "^1.8.0",
-    "loglevel-plugin-remote": "^0.6.8",
+    "loglevel-plugin-remote": "git+https://github.com/k2maan/loglevel-plugin-remote.git",
     "luxon": "^2.3.0",
     "mitt": "^2.1.0",
     "vue": "^3.2.26",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "file-saver": "^2.0.5",
     "http-status-codes": "^2.1.4",
     "loglevel": "^1.8.0",
+    "loglevel-plugin-remote": "^0.6.8",
     "luxon": "^2.3.0",
     "mitt": "^2.1.0",
     "vue": "^3.2.26",
@@ -54,9 +55,9 @@
     "eslint": "^7.32.0",
     "eslint-plugin-vue": "^8.0.3",
     "jest": "^27.1.0",
-    "ts-jest": "^27.0.4",
-    "typescript": "~4.1.5",
     "papaparse": "^5.3.1",
+    "ts-jest": "^27.0.4",
+    "typescript": "^4.1.6",
     "vue-cli-plugin-i18n": "^1.0.1",
     "vue-jest": "^5.0.0-0"
   }

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -1,0 +1,17 @@
+import { createLogger, StringifyObjectsHook, LoggerHook, LogEvent } from 'vue-logger-plugin'
+import axios from 'axios'
+
+const ServerLogHook: LoggerHook = {
+  async run(event: LogEvent) {
+    await axios.post('/log', { severity: event.level, data: event.argumentArray })
+  }
+}
+
+const logger = createLogger({
+  enabled: true,
+  level: 'debug',  
+  beforeHooks: [ StringifyObjectsHook ],
+  afterHooks: [ ServerLogHook ]
+})
+
+export default logger

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,13 +28,16 @@ import i18n from './i18n'
 import store from './store'
 import { DateTime } from 'luxon';
 
+import logger from './logger';
+
 const app = createApp(App)
   .use(IonicVue, {
     mode: 'md'
   })
   .use(router)
   .use(i18n)
-  .use(store);
+  .use(store)
+  .use(logger);
 
 // Filters are removed in Vue 3 and global filter introduced https://v3.vuejs.org/guide/migration/filters.html#global-filters
 app.config.globalProperties.$filters = {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -45,6 +45,7 @@ import { codeWorkingOutline, ellipsisVertical, personCircleOutline, storefrontOu
 import { mapGetters, useStore } from 'vuex';
 import { useRouter } from 'vue-router';
 import TimeZoneModal from '@/views/TimezoneModal.vue';
+import log from 'loglevel';
 
 export default defineComponent({
   name: 'Settings',
@@ -75,6 +76,10 @@ export default defineComponent({
         if (fac.facilityId == facility['detail'].value) {
           this.store.dispatch('user/setFacility', {'facility': fac});
           console.log(fac);
+          log.info('this is an info log')
+          log.trace('this is a trace log')
+          log.warn('this is a warning log')
+          log.error('err! this is an error log')
         }
       })
     },

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -46,6 +46,7 @@ import { mapGetters, useStore } from 'vuex';
 import { useRouter } from 'vue-router';
 import TimeZoneModal from '@/views/TimezoneModal.vue';
 import log from 'loglevel';
+import remote from 'loglevel-plugin-remote'
 
 export default defineComponent({
   name: 'Settings',
@@ -76,6 +77,7 @@ export default defineComponent({
         if (fac.facilityId == facility['detail'].value) {
           this.store.dispatch('user/setFacility', {'facility': fac});
           console.log(fac);
+          remote.apply(log, {});
           log.info('this is an info log')
           log.trace('this is a trace log')
           log.warn('this is a warning log')

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -45,8 +45,6 @@ import { codeWorkingOutline, ellipsisVertical, personCircleOutline, storefrontOu
 import { mapGetters, useStore } from 'vuex';
 import { useRouter } from 'vue-router';
 import TimeZoneModal from '@/views/TimezoneModal.vue';
-import log from 'loglevel';
-import remote from 'loglevel-plugin-remote'
 
 export default defineComponent({
   name: 'Settings',
@@ -77,11 +75,7 @@ export default defineComponent({
         if (fac.facilityId == facility['detail'].value) {
           this.store.dispatch('user/setFacility', {'facility': fac});
           console.log(fac);
-          remote.apply(log, {});
-          log.info('this is an info log')
-          log.trace('this is a trace log')
-          log.warn('this is a warning log')
-          log.error('err! this is an error log')
+          this.$log.error('Error log');
         }
       })
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,12 @@
       "dom",
       "dom.iterable",
       "scripthost"
-    ]
+    ],
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "declarationMap": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
## Related to #63 

## Description 
[vue-logger-plugin](https://github.com/dev-tavern/vue-logger-plugin) provides logging functionality for vue-specific applications through hooks. Supports sending logs to the remote server.

## Screenshot
![Screenshot from 2022-10-21 12-37-38](https://user-images.githubusercontent.com/59442907/197134491-0ea936e4-e797-4e65-ba04-9c699facd0e2.png)

