### PR TITLE
Fixed: issue of goToOms button working when url contains api/ but not working when it contains api only(#121)

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 const goToOms = (token: string, oms: string) => {
-  const link = (oms.startsWith('http') ? oms.replace('api/', "") : `https://${oms}.hotwax.io/`) + `?token=${token}`
+  const link = (oms.startsWith('http') ? oms.replace(/api\/?/, "") : `https://${oms}.hotwax.io/`) + `?token=${token}`
+  
   window.open(link, '_blank', 'noopener, noreferrer')
 }
 


### PR DESCRIPTION
### Related Issues
Related Issue: #121 

### Short Description and Why It's Useful
Fixed the issue when entering the full url for oms on login, and if the oms url does not contain api/ (and just contain api) at the last, then Go To OMS button does not work.

- Used a regExp in the replace function to replace the url whether it's "api" or "api/".


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)