### PR TITLE
Fixed: redirect user to launchpad in case of expired token

### DIFF
--- a/src/components/Login.ts
+++ b/src/components/Login.ts
@@ -1,5 +1,6 @@
 import { defineComponent } from "vue"
 import { loginContext as context, useAuthStore, appContext } from "../index"
+import { DateTime } from "luxon"
 
 export default defineComponent({
   template: `
@@ -34,6 +35,15 @@ export default defineComponent({
     async handleUserFlow(token: string, oms: string, expirationTime: string) {
       // logout to clear current user state
       await context.logout()
+
+      // checking if token from launchpad has expired and redirecting there only
+      if (+expirationTime < DateTime.now().toMillis()) {
+        console.error('User token has expired, redirecting to launchpad.')
+        this.errorMsg = 'User token has expired, redirecting to launchpad.'
+        const redirectUrl = window.location.origin + '/login' // current app URL
+        window.location.href = `${context.appLoginUrl}?isLoggedOut=true&redirectUrl=${redirectUrl}`
+        return
+      }
 
       // update the previously set values if the user opts ending the previous session
       this.authStore.$patch({


### PR DESCRIPTION
**Description** - 

Currently, if the token is expired on Launchpad, the user is allowed to open the app and the app shows an error stating 'Unable to login. Please contact the administrator'. 

Fixed this behaviour by checking the expiration manually and redirecting and logging out the user to Launchpad. This handling is done here taking future prospects of any third-party integrations or cross-app login into consideration.