### PR TITLE
Improved: pr workflow to remove node v14 and build apps on node v18

### DIFF
--- a/.github/workflows/common-pull-request.yml
+++ b/.github/workflows/common-pull-request.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
- Removed PR build check on node v14, as v14 reached End-of-Life
- Added support to check build on node v18, as v18 is on LTS