### PR TITLE
Fixed: firebase error on login if app is not configured for notifications support

### DIFF
--- a/src/components/Login.ts
+++ b/src/components/Login.ts
@@ -63,7 +63,7 @@ export default defineComponent({
       try {
         await context.login({ token, oms })
 
-        // check if firebase if configurations are there
+        // check if firebase configurations are there
         if (noitificationContext.appFirebaseConfig) {
           // initialising and connecting firebase app for notification support
           await initialiseFirebaseApp(

--- a/src/components/Login.ts
+++ b/src/components/Login.ts
@@ -63,13 +63,16 @@ export default defineComponent({
       try {
         await context.login({ token, oms })
 
-        // initialising and connecting firebase app for notification support
-        await initialiseFirebaseApp(
-          noitificationContext.appFirebaseConfig,
-          noitificationContext.appFirebaseVapidKey,
-          noitificationContext.storeClientRegistrationToken,
-          noitificationContext.addNotification,
-        )
+        // check if firebase if configurations are there
+        if (noitificationContext.appFirebaseConfig) {
+          // initialising and connecting firebase app for notification support
+          await initialiseFirebaseApp(
+            noitificationContext.appFirebaseConfig,
+            noitificationContext.appFirebaseVapidKey,
+            noitificationContext.storeClientRegistrationToken,
+            noitificationContext.addNotification,
+          )
+        }
 
         this.router.push('/')
       } catch (error) {


### PR DESCRIPTION
Fixed firebase config-related error on login if the app is not configured for notifications support (we are not passing Firebase configurations from the app to DXP).