### PR TITLE
Fixed: login failing due to missing locale preference in userProfile

### DIFF
--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -17,23 +17,22 @@ export const useUserStore = defineStore('user', {
   actions: {
     async setLocale(locale: string) {
       let newLocale, matchingLocale
+      newLocale = this.locale
       // handling if locale is not coming from userProfile
-      if (!locale) {
-        newLocale = this.locale
-      } else {
-        matchingLocale = Object.keys(this.localeOptions).find((option: string) => option === locale)
-        // If exact locale is not found, try to match the first two characters i.e primary code
-        matchingLocale = matchingLocale || Object.keys(this.localeOptions).find((option: string) => option.slice(0, 2) === locale.slice(0, 2))
-        newLocale = matchingLocale || this.locale
-      }
-
       try {
-        // update locale in state and globally
-        i18n.global.locale.value = newLocale
-        this.locale = newLocale
-        await userContext.setUserLocale({ newLocale })
+        if (locale) {
+          matchingLocale = Object.keys(this.localeOptions).find((option: string) => option === locale)
+          // If exact locale is not found, try to match the first two characters i.e primary code
+          matchingLocale = matchingLocale || Object.keys(this.localeOptions).find((option: string) => option.slice(0, 2) === locale.slice(0, 2))
+          newLocale = matchingLocale || this.locale
+          // update locale in state and globally
+          await userContext.setUserLocale({ newLocale })
+        }
       } catch (error) {
         console.error(error)
+      } finally {
+        i18n.global.locale.value = newLocale
+        this.locale = newLocale
       }
     }
   },

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -16,10 +16,16 @@ export const useUserStore = defineStore('user', {
   },
   actions: {
     async setLocale(locale: string) {
-      let matchingLocale = Object.keys(this.localeOptions).find((option: string) => option === locale)
-      // If exact locale is not found, try to match the first two characters i.e primary code
-      matchingLocale = matchingLocale || Object.keys(this.localeOptions).find((option: string) => option.slice(0, 2) === locale.slice(0, 2))
-      const newLocale = matchingLocale || this.locale
+      let newLocale, matchingLocale
+      // handling if locale is not coming from userProfile
+      if (!locale) {
+        newLocale = this.locale
+      } else {
+        matchingLocale = Object.keys(this.localeOptions).find((option: string) => option === locale)
+        // If exact locale is not found, try to match the first two characters i.e primary code
+        matchingLocale = matchingLocale || Object.keys(this.localeOptions).find((option: string) => option.slice(0, 2) === locale.slice(0, 2))
+        newLocale = matchingLocale || this.locale
+      }
 
       try {
         // update locale in state and globally


### PR DESCRIPTION
Fixed login failing due to missing locale preference configuration on user profile in Demo instance. Added undefined check for handling.