### PR TITLE
Fixed: loader which was not getting dismissed when API failed

### DIFF
--- a/src/components/DxpLogin.vue
+++ b/src/components/DxpLogin.vue
@@ -83,7 +83,7 @@ async function handleUserFlow(token: string, oms: string, expirationTime: string
     oms
   })
 
-  context.loader.present('Logging in')
+  await context.loader.present('Logging in')
   try {
     // redirect route will be returned for certain cases
     const redirectRoute = await context.login({ token, oms })


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #259 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Loader is now getting dismissed when there is an API failure to enhance the user experience. 


- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)