### PR TITLE
Fixed: issue in image component to render the apps local images correctly(#266)

### DIFF
--- a/src/components/DxpImage.vue
+++ b/src/components/DxpImage.vue
@@ -14,16 +14,16 @@ let resourceUrl = process.env.VUE_APP_RESOURCE_URL || "";
 
 const setImageUrl = () => {
   if (props.src) {
-    if (props.src.indexOf('assets/') != -1) {
-      // Assign directly in case of assets
-      imageUrl.value = props.src;
-    } else if (props.src.startsWith('http')) {
+    if (props.src.startsWith('http')) {
       // If starts with http, it is web url check for existence and assign
       checkIfImageExists(props.src).then(() => {
         imageUrl.value = props.src;
       }).catch(() => {
         console.error("Image doesn't exist");
       })
+    } else if (props.src.indexOf('assets/') != -1 || props.src.startsWith('/img/')) {
+      // Assign directly in case of assets or if image starts with /img/ (when url start with /img/ then the img is the local asset url of the app)
+      imageUrl.value = props.src;
     } else {
       // Image is from resource server, hence append to base resource url, check for existence and assign
       const newImageUrl = resourceUrl.concat(props.src)


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #266 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [x] Yes
- [ ] No

If using the `DxpImage` component from the package, update the `src` prop to pass a local data property containing the the assets url instead of directly using require with assets url in props.
Also if using local image component, update it to use `DxpImage` component.

```js
<DxpImage :src="emptyState" alt="empty state" />
.
.
emptyState: require('../assets/images/empty-state.png')
```

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/dxp-components#contribution-guideline)