### PR TITLE
Improved: clearing gitbook search modal queries on modal dismiss and promise for fetching resources (#313)

### DIFF
--- a/src/components/DxpGitBookSearch.vue
+++ b/src/components/DxpGitBookSearch.vue
@@ -5,7 +5,7 @@
   </ion-tab-button>
 
   <!-- Using inline modal(as recommended by ionic), also using it inline as the component inside modal is not getting mounted when using modalController -->
-  <ion-modal ref="gitBookSearchModal" trigger="gibook-search-modal">
+  <ion-modal ref="gitBookSearchModal" trigger="gibook-search-modal" @willDismiss="clearQueryState()">
     <ion-header>
       <ion-toolbar>
         <ion-buttons slot="start">
@@ -230,7 +230,7 @@ async function fetchSources() {
   isResourceLoading.value = true;
   const list = [] as any;
 
-  const responses = await Promise.all(answer.value.sources.map((source: any) => {
+  const responses = await (Promise as any).allSettled(answer.value.sources.map((source: any) => {
     if(source.type === "page") {
       return gitBookContext.getGitBookPage({
         pageId: source.page,
@@ -259,5 +259,18 @@ function redirectToDoc(item: any) {
 function searchRelatedQuestion(question: string) {
   queryString.value = question;
   askQuery()
+}
+
+function clearQueryState() {
+  selectedSegment.value = "search";
+  queryString.value = "";
+  searchedItems.value = [];
+  answer.value = {};
+
+  isLoading.value = false;
+
+  isResourceLoading.value = false;
+  sources.value = [];
+  isResourceFetched.value = false;
 }
 </script>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#313

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Clearing query state of gitbook search modal to have clear console on reopening.
- Used Promise.allSettled to fetch all resources even if one api fails.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [ ] Yes
- [ ] No


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/dxp-components#contribution-guideline)