### PR TITLE
Improved: added permission check over the 'Go To OMS' button (#270)

### DIFF
--- a/src/components/DxpOmsInstanceNavigator.vue
+++ b/src/components/DxpOmsInstanceNavigator.vue
@@ -11,7 +11,7 @@
     <ion-card-content>
       {{ $t('This is the name of the OMS you are connected to right now. Make sure that you are connected to the right instance before proceeding.') }}
     </ion-card-content>
-    <ion-button @click="goToOms(token.value, oms)" fill="clear">
+    <ion-button @click="goToOms(token.value, oms)" fill="clear" :disabled="!appContext.hasPermission('APP_COMMERCE_VIEW')">
       {{ $t('Go to OMS') }}
       <ion-icon slot="end" :icon="openOutline" />
     </ion-button>
@@ -32,6 +32,7 @@ import { goToOms } from '../utils';
 import { openOutline } from 'ionicons/icons'
 import { computed } from 'vue';
 import { useAuthStore } from "../store/auth";
+import { appContext } from "src";
 
 const authStore = useAuthStore();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,8 @@ export let dxpComponents = {
     loginContext.getConfig = options.getConfig
     loginContext.initialise = options.initialise
 
+    appContext.hasPermission = options.hasPermission
+
     // set a default locale in the state
     i18n.global.locale.value = useUserStore().getLocale
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#270

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added permission check over the 'Go To OMS' button.

<b>Note:</b> I have used Commerce user view permission which is a base permission to access the commerce. Also this permission is used in deciding the email template while reset password email action in employees details page.

### Related PR for testing
https://github.com/hotwax/preorder/pull/295

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [ ] Yes
- [ ] No


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/dxp-components#contribution-guideline)