### PR TITLE
Implemented: centralized product store selector (#193)

### DIFF
--- a/src/components/DxpMenuFooterNavigation.vue
+++ b/src/components/DxpMenuFooterNavigation.vue
@@ -40,13 +40,15 @@
 import { IonFooter, IonItem, IonLabel, IonNote, IonSelect, IonSelectOption, IonToolbar } from '@ionic/vue';
 import { appContext, useAuthStore } from "../index";
 import { computed } from 'vue';
+import { useUserStore } from 'src/store/user'
 
 const authStore = useAuthStore();
+const userStore = useUserStore()
 const appState = appContext.config.globalProperties.$store;
 const instanceUrl = computed(() => authStore.getOms); 
 const userAppState = computed(() => ({ 
   userProfile: appState.getters['user/getUserProfile'],
-  currentEComStore: appState.getters['user/getCurrentEComStore'],
+  currentEComStore: userStore.getCurrentEComStore,
   shopifyConfigs: appState.getters['user/getShopifyConfigs'],
   currentShopifyConfig: appState.getters['user/getCurrentShopifyConfig']
 }));

--- a/src/components/DxpProductIdentifier.vue
+++ b/src/components/DxpProductIdentifier.vue
@@ -30,6 +30,7 @@ import { IonCard, IonCardContent, IonCardHeader, IonCardTitle, IonItem, IonSelec
 import { useProductIdentificationStore } from 'src/store/productIdentification';
 import { useUserStore } from 'src/store/user'
 import { computed, onMounted } from 'vue';
+import { appContext } from "../index";
 
 const productIdentificationStore = useProductIdentificationStore();
 const userStore = useUserStore()

--- a/src/components/DxpProductIdentifier.vue
+++ b/src/components/DxpProductIdentifier.vue
@@ -34,16 +34,16 @@ import { computed, onMounted } from 'vue';
 const productIdentificationStore = useProductIdentificationStore();
 const userStore = useUserStore()
 
-const eComStore = computed(() =>  userStore.getCurrentEComStore)
+const currentEComStore = computed(() =>  userStore.getCurrentEComStore)
 const productIdentificationPref = computed(() => productIdentificationStore.getProductIdentificationPref);
 const productIdentificationOptions = productIdentificationStore.getProductIdentificationOptions;
 
 onMounted(() => {
-  productIdentificationStore.getIdentificationPref(eComStore.value.productStoreId);
+  productIdentificationStore.getIdentificationPref(currentEComStore.value.productStoreId);
 })
 
 function setProductIdentificationPref(value: string | any, id: string) {
-  productIdentificationStore.setProductIdentificationPref(id, value, eComStore.value.productStoreId)
+  productIdentificationStore.setProductIdentificationPref(id, value, currentEComStore.value.productStoreId)
 }
 
 </script>

--- a/src/components/DxpProductIdentifier.vue
+++ b/src/components/DxpProductIdentifier.vue
@@ -27,14 +27,14 @@
 
 <script setup lang="ts">
 import { IonCard, IonCardContent, IonCardHeader, IonCardTitle, IonItem, IonSelect, IonSelectOption } from '@ionic/vue';
-import { appContext } from 'src';
 import { useProductIdentificationStore } from 'src/store/productIdentification';
+import { useUserStore } from 'src/store/user'
 import { computed, onMounted } from 'vue';
 
 const productIdentificationStore = useProductIdentificationStore();
+const userStore = useUserStore()
 
-const appState = appContext.config.globalProperties.$store
-const eComStore = computed(() => appState.getters['user/getCurrentEComStore'])
+const eComStore = computed(() =>  userStore.getCurrentEComStore)
 const productIdentificationPref = computed(() => productIdentificationStore.getProductIdentificationPref);
 const productIdentificationOptions = productIdentificationStore.getProductIdentificationOptions;
 

--- a/src/components/DxpProductStoreSelector.vue
+++ b/src/components/DxpProductStoreSelector.vue
@@ -14,8 +14,7 @@
     </ion-card-content>
 
     <ion-item lines="none">
-      <ion-label> {{ $t("Select store") }} </ion-label>
-      <ion-select interface="popover" :placeholder="$t('store name')" :value="currentEComStore?.productStoreId" @ionChange="setEComStore($event)">
+      <ion-select :label="$t('Select store')" interface="popover" :placeholder="$t('store name')" :value="currentEComStore?.productStoreId" @ionChange="setEComStore($event)">
         <ion-select-option v-for="store in (productStores ? productStores : [])" :key="store.productStoreId" :value="store.productStoreId">{{ store.storeName }}</ion-select-option>
       </ion-select>
     </ion-item>

--- a/src/components/DxpProductStoreSelector.vue
+++ b/src/components/DxpProductStoreSelector.vue
@@ -1,0 +1,43 @@
+<template>
+  <ion-card>
+    <ion-card-header>
+      <ion-card-subtitle>
+        {{ $t("Product Store") }}
+      </ion-card-subtitle>
+      <ion-card-title>
+        {{ $t("Store") }}
+      </ion-card-title>
+    </ion-card-header>
+
+    <ion-card-content>
+      {{ $t('A store represents a company or a unique catalog of products. If your OMS is connected to multiple eCommerce stores selling different collections of products, you may have multiple Product Stores set up in HotWax Commerce.') }}
+    </ion-card-content>
+
+    <ion-item lines="none">
+      <ion-label> {{ $t("Select store") }} </ion-label>
+      <ion-select interface="popover" :placeholder="$t('store name')" :value="currentEComStore?.productStoreId" @ionChange="setEComStore($event)">
+        <ion-select-option v-for="store in (productStores ? productStores : [])" :key="store.productStoreId" :value="store.productStoreId">{{ store.storeName }}</ion-select-option>
+      </ion-select>
+    </ion-item>
+  </ion-card>
+</template>
+    
+<script setup lang="ts">
+import { IonCard, IonCardContent, IonCardHeader, IonCardTitle, IonCardSubtitle, IonItem, IonLabel, IonSelect, IonSelectOption } from '@ionic/vue';
+import { useUserStore } from 'src';
+import { computed } from 'vue';
+
+const userStore = useUserStore();
+
+const productStores = computed(() => userStore.getProductStores); 
+const currentEComStore = computed(() => userStore.getCurrentEComStore);
+
+const setEComStore = (event: any) => {
+  if (currentEComStore.value?.productStoreId !== event.detail.value) {
+    userStore.setEComStore({ 
+      eComStore: productStores.value.find((store: any) => store.productStoreId == event.detail.value),
+      userPrefTypeId: 'SELECTED_BRAND'
+    })
+  }
+}
+</script>

--- a/src/components/DxpProductStoreSelector.vue
+++ b/src/components/DxpProductStoreSelector.vue
@@ -27,7 +27,7 @@ import { useUserStore } from 'src';
 import { computed } from 'vue';
 
 const userStore = useUserStore();
-const emit = defineEmits(["updateEcomStore"])
+const emit = defineEmits(["updateEComStore"])
 
 const eComStores = computed(() => userStore.getProductStores); 
 const currentEComStore = computed(() => userStore.getCurrentEComStore);
@@ -35,6 +35,6 @@ const currentEComStore = computed(() => userStore.getCurrentEComStore);
 async function updateEComStore(eComStoreId: any) {
   const selectedProductStore = eComStores.value.find((store: any) => store.productStoreId == eComStoreId)
   await userStore.setEComStorePreference(selectedProductStore)
-  emit('updateEcomStore', selectedProductStore)
+  emit('updateEComStore', selectedProductStore)
 }
 </script>

--- a/src/components/DxpProductStoreSelector.vue
+++ b/src/components/DxpProductStoreSelector.vue
@@ -14,7 +14,7 @@
     </ion-card-content>
 
     <ion-item lines="none">
-      <ion-select :label="$t('Select store')" interface="popover" :placeholder="$t('store name')" :value="currentEComStore?.productStoreId" @ionChange="updateEComStore($event)">
+      <ion-select :label="$t('Select store')" interface="popover" :placeholder="$t('store name')" :value="currentEComStore?.productStoreId" @ionChange="updateEComStore($event.target.value)">
         <ion-select-option v-for="store in (eComStores ? eComStores : [])" :key="store.productStoreId" :value="store.productStoreId">{{ store.storeName }}</ion-select-option>
       </ion-select>
     </ion-item>
@@ -32,9 +32,9 @@ const emit = defineEmits(["updateEcomStore"])
 const eComStores = computed(() => userStore.getProductStores); 
 const currentEComStore = computed(() => userStore.getCurrentEComStore);
 
-async function updateEComStore(event: any) {
-  if (event.target.value && currentEComStore.value?.productStoreId !== event.detail.value) {
-    const selectedProductStore = eComStores.value.find((store: any) => store.productStoreId == event.detail.value)
+async function updateEComStore(eComStoreId: any) {
+  if (eComStoreId && currentEComStore.value?.productStoreId !== eComStoreId) {
+    const selectedProductStore = eComStores.value.find((store: any) => store.productStoreId == eComStoreId)
     await userStore.setEComStorePreference(selectedProductStore)
     emit('updateEcomStore', selectedProductStore)
   }

--- a/src/components/DxpProductStoreSelector.vue
+++ b/src/components/DxpProductStoreSelector.vue
@@ -14,7 +14,7 @@
     </ion-card-content>
 
     <ion-item lines="none">
-      <ion-select :label="$t('Select store')" interface="popover" :placeholder="$t('store name')" :value="currentEComStore?.productStoreId" @ionChange="setEComStore($event)">
+      <ion-select :label="$t('Select store')" interface="popover" :placeholder="$t('store name')" :value="currentEComStore?.productStoreId" @ionChange="setEComStore($event); $emit('updateEcomStore', $event)">
         <ion-select-option v-for="store in (productStores ? productStores : [])" :key="store.productStoreId" :value="store.productStoreId">{{ store.storeName }}</ion-select-option>
       </ion-select>
     </ion-item>

--- a/src/components/DxpProductStoreSelector.vue
+++ b/src/components/DxpProductStoreSelector.vue
@@ -14,8 +14,8 @@
     </ion-card-content>
 
     <ion-item lines="none">
-      <ion-select :label="$t('Select store')" interface="popover" :placeholder="$t('store name')" :value="currentEComStore?.productStoreId" @ionChange="setEComStore($event); $emit('updateEcomStore', $event.detail.value)">
-        <ion-select-option v-for="store in (productStores ? productStores : [])" :key="store.productStoreId" :value="store.productStoreId">{{ store.storeName }}</ion-select-option>
+      <ion-select :label="$t('Select store')" interface="popover" :placeholder="$t('store name')" :value="currentEComStore?.productStoreId" @ionChange="updateEComStore($event)">
+        <ion-select-option v-for="store in (eComStores ? eComStores : [])" :key="store.productStoreId" :value="store.productStoreId">{{ store.storeName }}</ion-select-option>
       </ion-select>
     </ion-item>
   </ion-card>
@@ -27,14 +27,16 @@ import { useUserStore } from 'src';
 import { computed } from 'vue';
 
 const userStore = useUserStore();
+const emit = defineEmits(["updateEcomStore"])
 
-const productStores = computed(() => userStore.getProductStores); 
+const eComStores = computed(() => userStore.getProductStores); 
 const currentEComStore = computed(() => userStore.getCurrentEComStore);
 
-const setEComStore = (event: any) => {
-  if (currentEComStore.value?.productStoreId !== event.detail.value) {
-    const selectedProductStore = productStores.value.find((store: any) => store.productStoreId == event.detail.value)
-    userStore.setEComStore(selectedProductStore)
+async function updateEComStore(event: any) {
+  if (event.target.value && currentEComStore.value?.productStoreId !== event.detail.value) {
+    const selectedProductStore = eComStores.value.find((store: any) => store.productStoreId == event.detail.value)
+    await userStore.setEComStorePreference(selectedProductStore)
+    emit('updateEcomStore', selectedProductStore)
   }
 }
 </script>

--- a/src/components/DxpProductStoreSelector.vue
+++ b/src/components/DxpProductStoreSelector.vue
@@ -14,7 +14,7 @@
     </ion-card-content>
 
     <ion-item lines="none">
-      <ion-select :label="$t('Select store')" interface="popover" :placeholder="$t('store name')" :value="currentEComStore?.productStoreId" @ionChange="setEComStore($event); $emit('updateEcomStore', $event)">
+      <ion-select :label="$t('Select store')" interface="popover" :placeholder="$t('store name')" :value="currentEComStore?.productStoreId" @ionChange="setEComStore($event); $emit('updateEcomStore', $event.detail.value)">
         <ion-select-option v-for="store in (productStores ? productStores : [])" :key="store.productStoreId" :value="store.productStoreId">{{ store.storeName }}</ion-select-option>
       </ion-select>
     </ion-item>
@@ -33,10 +33,8 @@ const currentEComStore = computed(() => userStore.getCurrentEComStore);
 
 const setEComStore = (event: any) => {
   if (currentEComStore.value?.productStoreId !== event.detail.value) {
-    userStore.setEComStore({ 
-      eComStore: productStores.value.find((store: any) => store.productStoreId == event.detail.value),
-      userPrefTypeId: 'SELECTED_BRAND'
-    })
+    const selectedProductStore = productStores.value.find((store: any) => store.productStoreId == event.detail.value)
+    userStore.setEComStore(selectedProductStore)
   }
 }
 </script>

--- a/src/components/DxpProductStoreSelector.vue
+++ b/src/components/DxpProductStoreSelector.vue
@@ -33,10 +33,8 @@ const eComStores = computed(() => userStore.getProductStores);
 const currentEComStore = computed(() => userStore.getCurrentEComStore);
 
 async function updateEComStore(eComStoreId: any) {
-  if (eComStoreId && currentEComStore.value?.productStoreId !== eComStoreId) {
-    const selectedProductStore = eComStores.value.find((store: any) => store.productStoreId == eComStoreId)
-    await userStore.setEComStorePreference(selectedProductStore)
-    emit('updateEcomStore', selectedProductStore)
-  }
+  const selectedProductStore = eComStores.value.find((store: any) => store.productStoreId == eComStoreId)
+  await userStore.setEComStorePreference(selectedProductStore)
+  emit('updateEcomStore', selectedProductStore)
 }
 </script>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -22,6 +22,7 @@ export { default as DxpLogin } from './DxpLogin.vue';
 export { default as DxpMenuFooterNavigation } from './DxpMenuFooterNavigation.vue';
 export { default as DxpOmsInstanceNavigator } from './DxpOmsInstanceNavigator.vue'
 export { default as DxpProductIdentifier } from "./DxpProductIdentifier.vue";
+export { default as DxpProductStoreSelector } from "./DxpProductStoreSelector.vue"
 export { default as DxpShopifyImg } from './DxpShopifyImg.vue';
 export { default as DxpUserProfile } from './DxpUserProfile.vue'
 export { default as DxpTimeZoneSwitcher } from './DxpTimeZoneSwitcher.vue'

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,7 @@ export let dxpComponents = {
     productIdentificationContext.getProductIdentificationPref = options.getProductIdentificationPref
     productIdentificationContext.setProductIdentificationPref = options.setProductIdentificationPref
      
-    productStoreContext.getEComStores = options.getEComStores
+    productStoreContext.getEComStoresByFacility = options.getEComStoresByFacility
     productStoreContext.setUserPreference = options.setUserPreference
     productStoreContext.getUserPreference = options.getUserPreference
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ export let dxpComponents = {
     productIdentificationContext.setProductIdentificationPref = options.setProductIdentificationPref
      
     productStoreContext.getEComStores = options.getEComStores
-    productStoreContext.setEComStore = options.setEComStore
+    productStoreContext.setUserPreference = options.setUserPreference
     productStoreContext.getUserPreference = options.getUserPreference
 
     notificationContext.addNotification = options.addNotification

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ declare var process: any;
 import { createPinia } from "pinia";
 import { useProductIdentificationStore } from "./store/productIdentification";
 import { useAuthStore } from "./store/auth";
-import { DxpAppVersionInfo, DxpGitBookSearch, DxpImage, DxpLanguageSwitcher, DxpLogin, DxpMenuFooterNavigation, DxpOmsInstanceNavigator, DxpProductIdentifier, DxpShopifyImg, DxpTimeZoneSwitcher, DxpUserProfile } from "./components";
+import { DxpAppVersionInfo, DxpGitBookSearch, DxpImage, DxpLanguageSwitcher, DxpLogin, DxpMenuFooterNavigation, DxpOmsInstanceNavigator, DxpProductIdentifier, DxpProductStoreSelector, DxpShopifyImg, DxpTimeZoneSwitcher, DxpUserProfile } from "./components";
 import { goToOms, getProductIdentificationValue } from "./utils";
 import { initialiseFirebaseApp } from "./utils/firebase"
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
@@ -25,6 +25,7 @@ let loginContext = {} as any
 let shopifyImgContext = {} as any
 let appContext = {} as any
 let productIdentificationContext = {} as any
+let productStoreContext = {} as any
 let notificationContext = {} as any
 let gitBookContext = {} as any
 let userContext = {} as any
@@ -74,6 +75,7 @@ export let dxpComponents = {
     app.component('DxpMenuFooterNavigation', DxpMenuFooterNavigation)
     app.component('DxpOmsInstanceNavigator', DxpOmsInstanceNavigator)
     app.component('DxpProductIdentifier', DxpProductIdentifier)
+    app.component('DxpProductStoreSelector', DxpProductStoreSelector)
     app.component('DxpShopifyImg', DxpShopifyImg)
     app.component('DxpTimeZoneSwitcher', DxpTimeZoneSwitcher)
     app.component('DxpUserProfile', DxpUserProfile)
@@ -96,7 +98,11 @@ export let dxpComponents = {
 
     productIdentificationContext.getProductIdentificationPref = options.getProductIdentificationPref
     productIdentificationContext.setProductIdentificationPref = options.setProductIdentificationPref
-    
+     
+    productStoreContext.getEComStores = options.getEComStores
+    productStoreContext.setEComStore = options.setEComStore
+    productStoreContext.getUserPreference = options.getUserPreference
+
     notificationContext.addNotification = options.addNotification
     notificationContext.appFirebaseConfig = options.appFirebaseConfig
     notificationContext.appFirebaseVapidKey = options.appFirebaseVapidKey
@@ -135,6 +141,7 @@ export {
   loginContext,
   notificationContext,
   productIdentificationContext,
+  productStoreContext,
   shopifyImgContext,
   translate,
   useAuthStore,

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,5 +1,3 @@
-declare const process: any;
-
 import { defineStore } from "pinia";
 import { DateTime } from 'luxon'
 

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,3 +1,5 @@
+declare const process: any;
+
 import { defineStore } from "pinia";
 import { DateTime } from 'luxon'
 
@@ -14,6 +16,11 @@ export const useAuthStore = defineStore('userAuth', {
   getters: {
     getToken: (state) => state.token,
     getOms: (state) => state.oms,
+    getBaseUrl: (state) => {
+      let baseURL = process.env.VUE_APP_BASE_URL;
+      if (!baseURL) baseURL = state.oms;
+      return baseURL.startsWith('http') ? baseURL : `https://${baseURL}.hotwax.io/api/`;
+    },
     isAuthenticated: (state) => {
       let isTokenExpired = false
       if (state.token.expiration) {

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -17,9 +17,8 @@ export const useAuthStore = defineStore('userAuth', {
     getToken: (state) => state.token,
     getOms: (state) => state.oms,
     getBaseUrl: (state) => {
-      let baseURL = process.env.VUE_APP_BASE_URL;
-      if (!baseURL) baseURL = state.oms;
-      return baseURL.startsWith('http') ? baseURL : `https://${baseURL}.hotwax.io/api/`;
+      let baseURL = state.oms
+      return baseURL.startsWith('http') ? baseURL.includes('/api') ? baseURL : `${baseURL}/api/` : `https://${baseURL}.hotwax.io/api/`;
     },
     isAuthenticated: (state) => {
       let isTokenExpired = false

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -114,11 +114,14 @@ export const useUserStore = defineStore('user', {
         this.currentEComStore = currentEComStore
       }
       try {
-        await productStoreContext.setEComStore(payload) 
+        await productStoreContext.setUserPreference({
+          userPrefTypeId: 'SELECTED_BRAND',
+          userPrefValue: payload.productStoreId
+        }) 
       } catch (error) {
         console.error('error', error)
       }
-      this.currentEComStore = payload.eComStore;
+      this.currentEComStore = payload;
     },
   },
   persist: true

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -79,11 +79,11 @@ export const useUserStore = defineStore('user', {
     updateTimeZone(tzId: string) {
       this.currentTimeZoneId = tzId
     },
-    async getEComStores(facilityId?: any) {
+    async getEComStoresByFacility(facilityId?: any) {
       const authStore = useAuthStore();
     
       try {
-        const response = await productStoreContext.getEComStores(authStore.getToken.value, authStore.getBaseUrl, 100, facilityId);
+        const response = await productStoreContext.getEComStoresByFacility(authStore.getToken.value, authStore.getBaseUrl, 100, facilityId);
         this.eComStores = response;
       } catch (error) {
         console.error(error);
@@ -93,7 +93,7 @@ export const useUserStore = defineStore('user', {
     async getEComStorePreference(userPrefTypeId: any) {
       const authStore = useAuthStore();
 
-      if(!this.eComStores) {
+      if(!this.eComStores.length) {
         return;
       }
       let preferredStore = this.eComStores[0];

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -84,6 +84,7 @@ export const useUserStore = defineStore('user', {
     updateTimeZone(tzId: string) {
       this.currentTimeZoneId = tzId
     },
+    // Facility api calls - retrieve user facilities & get/set preferred facility
     async getUserFacilities(partyId: any, facilityGroupId: any, isAdminUser: boolean) {
       const authStore = useAuthStore();
 
@@ -126,6 +127,7 @@ export const useUserStore = defineStore('user', {
       }
       this.currentFacility = payload;
     },
+    // ECom store api calls - fetch stores by facility & get/set user store preferences
     async getEComStoresByFacility(facilityId?: any) {
       const authStore = useAuthStore();
     

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -87,38 +87,32 @@ export const useUserStore = defineStore('user', {
         this.current.stores = response;
       } catch (error) {
         console.error(error);
-        this.current.stores = [];
       }
+      return this.current.stores
     },
     async getPreferredStore(userPrefTypeId: any) {
-      const authStore = useAuthStore();
       let preferredStore = {} as any;
-    
-      if (this.current.stores.length) {
-        preferredStore = this.current.stores[0];
+      const authStore = useAuthStore();
+      preferredStore = this.current.stores[0];
+
+      try {
         let preferredStoreId = '';
-    
-        try {
-          preferredStoreId = await productStoreContext.getUserPreference(authStore.getToken.value, authStore.getBaseUrl, userPrefTypeId);
+        preferredStoreId = await productStoreContext.getUserPreference(authStore.getToken.value, authStore.getBaseUrl, userPrefTypeId);
+
+        if(preferredStoreId) {
           const store = this.current.stores.find((store: any) => store.productStoreId === preferredStoreId);
-          if (store) {
-            preferredStore = store;
-          }
-          this.currentEComStore = preferredStore;
-          return Promise.resolve(preferredStoreId);
-        } catch (error) {
-          throw error;
+          store && (preferredStore = store)
         }
-      } else {
-        this.currentEComStore = {};
+      } catch (error) {
+        console.error(error);
       }
+      this.currentEComStore = preferredStore;
     },
     async setEComStore(payload: any) {
       const currentEComStore = JSON.parse(JSON.stringify(this.getCurrentEComStore))
       if(!payload) {
         this.currentEComStore = currentEComStore
       }
-
       try {
         await productStoreContext.setEComStore(payload) 
       } catch (error) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#193 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Created the `DxpProductStoreSelector` component with a UI to show the product store list.
- Added a feature to select and set the product store as the current store.
- Added actions to call `oms-apis` to get the stores, preferred store, and set the current store.
- Added `getters` to retrieve all stores and the current store.

### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [ ] Yes
- [x] No


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/dxp-components#contribution-guideline)