### PR TITLE
Implemented: centralized facility selector(#228)

### DIFF
--- a/src/components/DxpFacilitySwitcher.vue
+++ b/src/components/DxpFacilitySwitcher.vue
@@ -144,7 +144,7 @@ function preventSpecialCharacters($event: any) {
 async function updateFacility() {
   const selectedFacility = facilities.value.find((facility: any) => facility.facilityId === selectedFacilityId.value)
   await userStore.setFacilityPreference(selectedFacility)
-  emit('updateFacility', selectedFacility.facilityId);
+  emit('updateFacility', selectedFacility);
   closeModal();
 }
 

--- a/src/components/DxpFacilitySwitcher.vue
+++ b/src/components/DxpFacilitySwitcher.vue
@@ -13,7 +13,7 @@
         {{ currentFacility.facilityName }}
         <p>{{ currentFacility.facilityId }}</p>
       </ion-label>
-      <ion-button id="open-facility-modal" slot="end" fill="outline" color="dark">Change</ion-button>
+      <ion-button id="open-facility-modal" slot="end" fill="outline" color="dark">{{ $t('Change')}}</ion-button>
     </ion-item>
   </ion-card>
   <!-- Using inline modal(as recommended by ionic), also using it inline as the component inside modal is not getting mounted when using modalController -->
@@ -42,7 +42,7 @@
             </ion-item>
           </div>
           <!-- Empty state -->
-          <div class="empty-state" v-else-if="filteredFacilities.length === 0">
+          <div class="empty-state" v-else-if="!filteredFacilities.length">
             <p>{{ $t("No facilities found") }}</p>
           </div>
           <div v-else>
@@ -119,11 +119,13 @@ function loadFacilities() {
 
 const findFacility = () => {
   isLoading.value = true
-  const searchedString = queryString.value.toLowerCase();
-  filteredFacilities.value = facilities.value.filter((facility: any) => 
-    facility.facilityName.toLowerCase().match(searchedString) || 
-    facility.facilityId.toLowerCase().match(searchedString)
-  );
+  const searchedString = queryString.value.trim().toLowerCase();
+  if(searchedString) {
+    filteredFacilities.value = facilities.value.filter((facility: any) => 
+      facility.facilityName.toLowerCase().includes(searchedString) || 
+      facility.facilityId.toLowerCase().includes(searchedString)
+    );
+  }
   isLoading.value = false
 }
 
@@ -139,10 +141,10 @@ function preventSpecialCharacters($event: any) {
 
 function setFacility() {
   const selectedFacility = facilities.value.find((facility: any) => facility.facilityId === selectedFacilityId.value)
-  if(selectedFacility) {
-    userStore.setFacility(selectedFacility)
+  const isUpdated = userStore.setFacility(selectedFacility)
+  if(isUpdated) {
+    emit('updateFacility', selectedFacility.facilityId);
   }
-  emit('updateFacility', selectedFacility.facilityId);
   closeModal();
 }
 

--- a/src/components/DxpFacilitySwitcher.vue
+++ b/src/components/DxpFacilitySwitcher.vue
@@ -125,6 +125,8 @@ const findFacility = () => {
       facility.facilityName.toLowerCase().includes(searchedString) || 
       facility.facilityId.toLowerCase().includes(searchedString)
     );
+  } else {
+    filteredFacilities.value = facilities.value;
   }
   isLoading.value = false
 }

--- a/src/components/DxpFacilitySwitcher.vue
+++ b/src/components/DxpFacilitySwitcher.vue
@@ -13,16 +13,16 @@
         {{ currentFacility.facilityName }}
         <p>{{ currentFacility.facilityId }}</p>
       </ion-label>
-      <ion-button id="select-facility-modal" slot="end" fill="outline" color="dark">Change</ion-button>
+      <ion-button id="open-facility-modal" slot="end" fill="outline" color="dark">Change</ion-button>
     </ion-item>
   </ion-card>
   <!-- Using inline modal(as recommended by ionic), also using it inline as the component inside modal is not getting mounted when using modalController -->
-  <ion-modal ref="facilityModal" trigger="select-facility-modal" @didPresent="" @didDismiss="">
+  <ion-modal ref="facilityModal" trigger="open-facility-modal" @didPresent="loadFacilities()" @didDismiss="clearSearch()">
     <ion-header>
       <ion-toolbar>
         <ion-buttons slot="start">
           <ion-button @click="closeModal">
-            <ion-icon :icon="closeOutline" />
+            <ion-icon :icon="closeOutline"/>
           </ion-button>
         </ion-buttons>
         <ion-title>{{ $t("Select Facility") }}</ion-title>
@@ -32,8 +32,8 @@
       <ion-searchbar @ionFocus="selectSearchBarText($event)" :placeholder="$t('Search facilities')" v-model="queryString" @keyup.enter="queryString = $event.target.value; findFacility()" @keydown="preventSpecialCharacters($event)"/>
     </ion-toolbar>
     <ion-content>
-      <div>
-        <ion-radio-group v-model="selectedFacilityId">
+      <ion-radio-group v-model="selectedFacilityId">
+        <ion-list>
           <!-- Loading state -->
           <div class="empty-state" v-if="isLoading">
             <ion-item lines="none">
@@ -41,8 +41,11 @@
               {{ $t("Fetching facilities") }}
             </ion-item>
           </div>
-
-          <ion-list v-if="filteredFacilities.length ">
+          <!-- Empty state -->
+          <div class="empty-state" v-else-if="filteredFacilities.length === 0">
+            <p>{{ $t("No facilities found") }}</p>
+          </div>
+          <div v-else>
             <ion-item v-for="facility in filteredFacilities" :key="facility.facilityId">
               <ion-radio label-placement="end" justify="start" :value="facility.facilityId">
                 <ion-label>
@@ -51,13 +54,9 @@
                 </ion-label>
               </ion-radio>
             </ion-item>
-          </ion-list>
-          <!-- Empty state -->
-          <div class="empty-state" v-else>
-            <p>{{ $t("No facilities found") }}</p>
           </div>
-        </ion-radio-group>
-      </div>
+        </ion-list>
+      </ion-radio-group>
 
       <ion-fab vertical="bottom" horizontal="end" slot="fixed">
         <ion-fab-button :disabled="selectedFacilityId === currentFacility.facilityId" @click="setFacility">
@@ -103,14 +102,19 @@ const currentFacility = computed(() => userStore.getCurrentFacility)
 
 const facilityModal = ref()
 const queryString = ref('')
-const isLoading = ref(false);
-const filteredFacilities = ref(facilities.value)
+const isLoading = ref(true);
+const filteredFacilities = ref([])
 const selectedFacilityId = ref(currentFacility.value.facilityId)
 
 const emit = defineEmits(["updateFacility"])
 
 const closeModal = () => {
   facilityModal.value.$el.dismiss(null, 'cancel');
+}
+
+function loadFacilities() {
+  filteredFacilities.value = facilities.value;
+  isLoading.value = false;
 }
 
 const findFacility = () => {
@@ -140,6 +144,12 @@ function setFacility() {
   }
   emit('updateFacility', selectedFacility.facilityId);
   closeModal();
+}
+
+function clearSearch() {
+  queryString.value = ''
+  filteredFacilities.value = []
+  isLoading.value = true
 }
 </script>
 

--- a/src/components/DxpFacilitySwitcher.vue
+++ b/src/components/DxpFacilitySwitcher.vue
@@ -59,7 +59,7 @@
       </ion-radio-group>
 
       <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-        <ion-fab-button :disabled="selectedFacilityId === currentFacility.facilityId" @click="setFacility">
+        <ion-fab-button :disabled="selectedFacilityId === currentFacility.facilityId" @click="updateFacility">
           <ion-icon :icon="saveOutline" />
         </ion-fab-button>
       </ion-fab>
@@ -141,12 +141,10 @@ function preventSpecialCharacters($event: any) {
   if(/[`!@#$%^&*()_+\-=\\|,.<>?~]/.test($event.key)) $event.preventDefault();
 }
 
-function setFacility() {
+async function updateFacility() {
   const selectedFacility = facilities.value.find((facility: any) => facility.facilityId === selectedFacilityId.value)
-  const isUpdated = userStore.setFacility(selectedFacility)
-  if(isUpdated) {
-    emit('updateFacility', selectedFacility.facilityId);
-  }
+  await userStore.setFacilityPreference(selectedFacility)
+  emit('updateFacility', selectedFacility.facilityId);
   closeModal();
 }
 
@@ -159,6 +157,6 @@ function clearSearch() {
 
 <style scoped>
 ion-content {
-  --padding-bottom: 70px;
+  --padding-bottom: 80px;
 }
 </style>

--- a/src/components/DxpFacilitySwitcher.vue
+++ b/src/components/DxpFacilitySwitcher.vue
@@ -1,0 +1,147 @@
+<template>
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>
+        {{ $t('Facility') }}
+      </ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      {{ $t('Specify which facility you want to operate from. Order, inventory and other configuration data will be specific to the facility you select.') }}
+    </ion-card-content>
+    <ion-item lines="none">
+      <ion-label>
+        {{ currentFacility.facilityName }}
+        <p>{{ currentFacility.facilityId }}</p>
+      </ion-label>
+      <ion-button id="select-facility-modal" slot="end" fill="outline" color="dark">Change</ion-button>
+    </ion-item>
+  </ion-card>
+  <!-- Using inline modal(as recommended by ionic), also using it inline as the component inside modal is not getting mounted when using modalController -->
+  <ion-modal ref="facilityModal" trigger="select-facility-modal" @didPresent="" @didDismiss="">
+    <ion-header>
+      <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-button @click="closeModal">
+            <ion-icon :icon="closeOutline" />
+          </ion-button>
+        </ion-buttons>
+        <ion-title>{{ $t("Select Facility") }}</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-toolbar>
+      <ion-searchbar @ionFocus="selectSearchBarText($event)" :placeholder="$t('Search facilities')" v-model="queryString" @keyup.enter="queryString = $event.target.value; findFacility()" @keydown="preventSpecialCharacters($event)"/>
+    </ion-toolbar>
+    <ion-content class="ion-padding">
+      <div>
+        <ion-radio-group v-model="selectedFacilityId">
+          <!-- Loading state -->
+          <div class="empty-state" v-if="isLoading">
+            <ion-item lines="none">
+              <ion-spinner color="secondary" name="crescent" slot="start" />
+              {{ $t("Fetching facilities") }}
+            </ion-item>
+          </div>
+
+          <ion-list v-if="filteredFacilities.length ">
+            <ion-item v-for="facility in filteredFacilities" :key="facility.facilityId">
+              <ion-radio label-placement="end" justify="start" :value="facility.facilityId">
+                <ion-label>
+                  {{ facility.facilityName }}
+                  <p>{{ facility.facilityId }}</p>
+                </ion-label>
+              </ion-radio>
+            </ion-item>
+          </ion-list>
+          <!-- Empty state -->
+          <div class="empty-state" v-else>
+            <p>{{ $t("No facilities found") }}</p>
+          </div>
+        </ion-radio-group>
+      </div>
+
+      <ion-fab vertical="bottom" horizontal="end" slot="fixed">
+        <ion-fab-button :disabled="selectedFacilityId === currentFacility.facilityId" @click="setFacility">
+          <ion-icon :icon="saveOutline" />
+        </ion-fab-button>
+      </ion-fab>
+    </ion-content>
+  </ion-modal>
+</template>
+
+<script setup lang="ts">
+import { 
+  IonButton,
+  IonButtons,
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardTitle,
+  IonContent,
+  IonFab,
+  IonFabButton,
+  IonHeader,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonModal,
+  IonRadio,
+  IonRadioGroup,
+  IonSearchbar,
+  IonSpinner,
+  IonTitle,
+  IonToolbar
+} from '@ionic/vue';
+import { closeOutline, saveOutline } from "ionicons/icons";
+import { useUserStore } from 'src/store/user';
+import { computed, ref } from 'vue';
+
+const userStore = useUserStore();
+
+const facilities = computed(() => userStore.getFacilites)
+const currentFacility = computed(() => userStore.getCurrentFacility)
+
+const facilityModal = ref()
+const queryString = ref('')
+const isLoading = ref(false);
+const filteredFacilities = ref(facilities.value)
+const selectedFacilityId = ref(currentFacility.value.facilityId)
+
+const closeModal = () => {
+  facilityModal.value.$el.dismiss(null, 'cancel');
+}
+
+const findFacility = () => {
+  isLoading.value = true
+  const searchedString = queryString.value.toLowerCase();
+  filteredFacilities.value = facilities.value.filter((facility: any) => 
+    facility.facilityName.toLowerCase().match(searchedString) || 
+    facility.facilityId.toLowerCase().match(searchedString)
+  );
+  isLoading.value = false
+}
+
+async function selectSearchBarText(event: any) {
+  const element = await event.target.getInputElement()
+  element.select();
+}
+
+function preventSpecialCharacters($event: any) {
+  // Searching special characters fails the API, hence, they must be omitted
+  if(/[`!@#$%^&*()_+\-=\\|,.<>?~]/.test($event.key)) $event.preventDefault();
+}
+
+function setFacility() {
+  const selectedFacility = facilities.value.find((facility: any) => facility.facilityId === selectedFacilityId.value)
+  if(selectedFacility) {
+    userStore.setFacility(selectedFacility)
+  }
+  closeModal();
+}
+</script>
+
+<style scoped>
+ion-content {
+  --padding-bottom: 70px;
+}
+</style>

--- a/src/components/DxpFacilitySwitcher.vue
+++ b/src/components/DxpFacilitySwitcher.vue
@@ -31,7 +31,7 @@
     <ion-toolbar>
       <ion-searchbar @ionFocus="selectSearchBarText($event)" :placeholder="$t('Search facilities')" v-model="queryString" @keyup.enter="queryString = $event.target.value; findFacility()" @keydown="preventSpecialCharacters($event)"/>
     </ion-toolbar>
-    <ion-content class="ion-padding">
+    <ion-content>
       <div>
         <ion-radio-group v-model="selectedFacilityId">
           <!-- Loading state -->
@@ -107,6 +107,8 @@ const isLoading = ref(false);
 const filteredFacilities = ref(facilities.value)
 const selectedFacilityId = ref(currentFacility.value.facilityId)
 
+const emit = defineEmits(["updateFacility"])
+
 const closeModal = () => {
   facilityModal.value.$el.dismiss(null, 'cancel');
 }
@@ -136,6 +138,7 @@ function setFacility() {
   if(selectedFacility) {
     userStore.setFacility(selectedFacility)
   }
+  emit('updateFacility', selectedFacility.facilityId);
   closeModal();
 }
 </script>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -15,6 +15,7 @@ import '@ionic/vue/css/flex-utils.css';
 import '@ionic/vue/css/display.css';
 
 export { default as DxpAppVersionInfo } from './DxpAppVersionInfo.vue';
+export { default as DxpFacilitySwitcher } from './DxpFacilitySwitcher.vue'
 export { default as DxpGitBookSearch } from './DxpGitBookSearch.vue';
 export { default as DxpImage } from './DxpImage.vue';
 export { default as DxpLanguageSwitcher } from './DxpLanguageSwitcher.vue';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ declare var process: any;
 import { createPinia } from "pinia";
 import { useProductIdentificationStore } from "./store/productIdentification";
 import { useAuthStore } from "./store/auth";
-import { DxpAppVersionInfo, DxpGitBookSearch, DxpImage, DxpLanguageSwitcher, DxpLogin, DxpMenuFooterNavigation, DxpOmsInstanceNavigator, DxpProductIdentifier, DxpShopifyImg, DxpTimeZoneSwitcher, DxpUserProfile } from "./components";
+import { DxpAppVersionInfo, DxpFacilitySwitcher, DxpGitBookSearch, DxpImage, DxpLanguageSwitcher, DxpLogin, DxpMenuFooterNavigation, DxpOmsInstanceNavigator, DxpProductIdentifier, DxpShopifyImg, DxpTimeZoneSwitcher, DxpUserProfile } from "./components";
 import { goToOms, getProductIdentificationValue } from "./utils";
 import { initialiseFirebaseApp } from "./utils/firebase"
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
@@ -25,6 +25,7 @@ let loginContext = {} as any
 let shopifyImgContext = {} as any
 let appContext = {} as any
 let productIdentificationContext = {} as any
+let facilityContext = {} as any
 let notificationContext = {} as any
 let gitBookContext = {} as any
 let userContext = {} as any
@@ -67,6 +68,7 @@ export let dxpComponents = {
     })
 
     app.component('DxpAppVersionInfo', DxpAppVersionInfo)
+    app.component('DxpFacilitySwitcher', DxpFacilitySwitcher)
     app.component('DxpGitBookSearch', DxpGitBookSearch)
     app.component('DxpImage', DxpImage)
     app.component('DxpLanguageSwitcher', DxpLanguageSwitcher)
@@ -96,6 +98,10 @@ export let dxpComponents = {
 
     productIdentificationContext.getProductIdentificationPref = options.getProductIdentificationPref
     productIdentificationContext.setProductIdentificationPref = options.setProductIdentificationPref
+
+    facilityContext.getUserFacilities = options.getUserFacilities
+    facilityContext.setUserPreference = options.setUserPreference
+    facilityContext.getUserPreference = options.getUserPreference
     
     notificationContext.addNotification = options.addNotification
     notificationContext.appFirebaseConfig = options.appFirebaseConfig
@@ -135,6 +141,7 @@ export {
   loginContext,
   notificationContext,
   productIdentificationContext,
+  facilityContext,
   shopifyImgContext,
   translate,
   useAuthStore,

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,3 +1,5 @@
+declare const process: any;
+
 import { defineStore } from "pinia";
 import { DateTime } from 'luxon'
 
@@ -14,6 +16,11 @@ export const useAuthStore = defineStore('userAuth', {
   getters: {
     getToken: (state) => state.token,
     getOms: (state) => state.oms,
+    getBaseUrl: (state) => {
+      let baseURL = process.env.VUE_APP_BASE_URL;
+      if (!baseURL) baseURL = state.oms;
+      return baseURL.startsWith('http') ? baseURL : `https://${baseURL}.hotwax.io/api/`;
+    },
     isAuthenticated: (state) => {
       let isTokenExpired = false
       if (state.token.expiration) {

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,5 +1,3 @@
-declare const process: any;
-
 import { defineStore } from "pinia";
 import { DateTime } from 'luxon'
 
@@ -17,9 +15,8 @@ export const useAuthStore = defineStore('userAuth', {
     getToken: (state) => state.token,
     getOms: (state) => state.oms,
     getBaseUrl: (state) => {
-      let baseURL = process.env.VUE_APP_BASE_URL;
-      if (!baseURL) baseURL = state.oms;
-      return baseURL.startsWith('http') ? baseURL : `https://${baseURL}.hotwax.io/api/`;
+      let baseURL = state.oms
+      return baseURL.startsWith('http') ? baseURL.includes('/api') ? baseURL : `${baseURL}/api/` : `https://${baseURL}.hotwax.io/api/`;
     },
     isAuthenticated: (state) => {
       let isTokenExpired = false

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,6 +1,5 @@
 import { defineStore } from "pinia";
-import { appContext, i18n, translate, userContext, useAuthStore } from "../../src";
-import { hasError } from "@hotwax/oms-api";
+import { i18n, translate, userContext, useAuthStore } from "../../src";
 import { DateTime } from "luxon";
 import { showToast } from "src/utils";
 import { facilityContext } from "../index";

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -93,18 +93,18 @@ export const useUserStore = defineStore('user', {
     },
 
     async setFacility(payload: any) {
-      const currentFacility = JSON.parse(JSON.stringify(this.getCurrentFacility))
-      if(!payload) this.currentFacility = currentFacility
 
       try {
         await facilityContext.setUserPreference({
           userPrefTypeId: 'SELECTED_FACILITY',
           userPrefValue: payload.facilityId
         }) 
+        this.currentFacility = payload;
+        return true;
       } catch (error) {
         console.error('error', error)
       }
-      this.currentFacility = payload;
+      return false;
     },
 
     async getPreferredFacility(userPrefTypeId: any) {

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -105,19 +105,17 @@ export const useUserStore = defineStore('user', {
       this.currentFacility = payload;
     },
 
-    async getPreferredFacility(userPrefTypeId: any) {
+    async getFacilityPreference(userPrefTypeId: any) {
       const authStore = useAuthStore();
-      let preferredFacility = {} as any;
 
       if (!this.facilities.length) {
         return;
       }
-      preferredFacility = this.facilities[0];
+      let preferredFacility = this.facilities[0];
    
       try {
-        let preferredFacilityId = '';
-        preferredFacilityId = await facilityContext.getUserPreference(authStore.getToken.value, authStore.getBaseUrl, userPrefTypeId);
-        if(preferredFacility) {
+        let preferredFacilityId = await facilityContext.getUserPreference(authStore.getToken.value, authStore.getBaseUrl, userPrefTypeId);
+        if(preferredFacilityId) {
           const facility = this.facilities.find((facility: any) => facility.facilityId === preferredFacilityId);
           facility && (preferredFacility = facility)
         }

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -13,7 +13,7 @@ export const useUserStore = defineStore('user', {
       locale: 'en-US',
       currentTimeZoneId: '',
       timeZones: [],
-      facilities: {} as any,
+      facilities: [],
       currentFacility: {} as any
     }
   },
@@ -22,7 +22,7 @@ export const useUserStore = defineStore('user', {
     getLocaleOptions: (state) => state.localeOptions,
     getTimeZones: (state) => state.timeZones,
     getCurrentTimeZone: (state) => state.currentTimeZoneId,
-    getFacilites: (state) => state.facilities.itemList,
+    getFacilites: (state) => state.facilities,
     getCurrentFacility: (state) => state.currentFacility
   },
   actions: {
@@ -85,38 +85,40 @@ export const useUserStore = defineStore('user', {
 
       try {
         const response = await facilityContext.getUserFacilities(authStore.getToken.value, authStore.getBaseUrl, partyId, facilityGroupId, isAdminUser);
-        this.facilities.itemList = response;
+        this.facilities = response;
       } catch (error) {
         console.error(error);
       }
-      return this.facilities.itemList
+      return this.facilities
     },
 
-    async setFacility(payload: any) {
+    async setFacilityPreference(payload: any) {
 
       try {
         await facilityContext.setUserPreference({
           userPrefTypeId: 'SELECTED_FACILITY',
           userPrefValue: payload.facilityId
         }) 
-        this.currentFacility = payload;
-        return true;
       } catch (error) {
         console.error('error', error)
       }
-      return false;
+      this.currentFacility = payload;
     },
 
     async getPreferredFacility(userPrefTypeId: any) {
       const authStore = useAuthStore();
       let preferredFacility = {} as any;
-      preferredFacility = this.facilities.itemList[0];
 
+      if (!this.facilities.length) {
+        return;
+      }
+      preferredFacility = this.facilities[0];
+   
       try {
         let preferredFacilityId = '';
         preferredFacilityId = await facilityContext.getUserPreference(authStore.getToken.value, authStore.getBaseUrl, userPrefTypeId);
         if(preferredFacility) {
-          const facility = this.facilities.itemList.find((facility: any) => facility.facilityId === preferredFacilityId);
+          const facility = this.facilities.find((facility: any) => facility.facilityId === preferredFacilityId);
           facility && (preferredFacility = facility)
         }
       } catch (error) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#228 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

- Created the `DxpFacilitySwitcher` component with a UI that displays an `ion-card` and `ion-modal` to select a facility.  
- The list of facilities now includes the `facilityId` as well.  
- Added a feature to select a facility using radio buttons and set it as the current facility.  
- Added actions to call OMS APIs to retrieve facilities, the preferred facility, and set the current facility.  
- Added getters to retrieve all facilities and the current facility.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2024-09-05 12-36-07](https://github.com/user-attachments/assets/b93ee3f0-89d8-418a-a9ea-8ae508509517)
![Screenshot from 2024-09-05 12-35-50](https://github.com/user-attachments/assets/421ad0fe-19b3-44b5-8009-16ec60c5686b)


### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [ ] Yes
- [x] No


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/dxp-components#contribution-guideline)