### PR TITLE
Improved: removed the 2nd ion-toolbar & moved the ion-searchbar inside the ion-content(#228)

### DIFF
--- a/src/components/DxpFacilitySwitcher.vue
+++ b/src/components/DxpFacilitySwitcher.vue
@@ -28,10 +28,8 @@
         <ion-title>{{ $t("Select Facility") }}</ion-title>
       </ion-toolbar>
     </ion-header>
-    <ion-toolbar>
-      <ion-searchbar @ionFocus="selectSearchBarText($event)" :placeholder="$t('Search facilities')" v-model="queryString" @keyup.enter="queryString = $event.target.value; findFacility()" @keydown="preventSpecialCharacters($event)"/>
-    </ion-toolbar>
     <ion-content>
+      <ion-searchbar @ionFocus="selectSearchBarText($event)" :placeholder="$t('Search facilities')" v-model="queryString" @keyup.enter="queryString = $event.target.value; findFacility()" @keydown="preventSpecialCharacters($event)"/>
       <ion-radio-group v-model="selectedFacilityId">
         <ion-list>
           <!-- Loading state -->


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#228 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

For the facility selector modal, the second `ion-toolbar` component was removed, and the `ion-searchbar` was moved inside the `ion-content`.

### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [ ] Yes
- [x] No


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/dxp-components#contribution-guideline)