### PR TITLE
Improved: Added a check to the "Change" button in the Facility Switcher(#228)

### DIFF
--- a/src/components/DxpFacilitySwitcher.vue
+++ b/src/components/DxpFacilitySwitcher.vue
@@ -13,7 +13,7 @@
         {{ currentFacility.facilityName }}
         <p>{{ currentFacility.facilityId }}</p>
       </ion-label>
-      <ion-button id="open-facility-modal" slot="end" fill="outline" color="dark">{{ $t('Change')}}</ion-button>
+      <ion-button v-if="facilities?.length > 1" id="open-facility-modal" slot="end" fill="outline" color="dark">{{ $t('Change')}}</ion-button>
     </ion-item>
   </ion-card>
   <!-- Using inline modal(as recommended by ionic), also using it inline as the component inside modal is not getting mounted when using modalController -->


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#228

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added a check on the `Change` button to display it on the UI based on the association of the logged-in user."
- If the user has more than one facility associated with them, the Change button will be visible on the UI. Otherwise, it will not be visible if the user has only one associated facility.

### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [ ] Yes
- [x] No


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/dxp-components#contribution-guideline)