### PR TITLE
Implemented: Dxp pagination component(#322)

### DIFF
--- a/src/components/DxpPagination.vue
+++ b/src/components/DxpPagination.vue
@@ -7,14 +7,14 @@
   </ion-button>
 
   <ion-button
-    v-for="pageCount in getDisplayedPageCounts()"
-    :key="pageCount"
+    v-for="pageIndex in getDisplayedPageCounts()"
+    :key="pageIndex"
     fill="clear"
-    :size="currentPage === pageCount ? 'default' : 'small'"
-    :color="currentPage === pageCount ? 'dark' : 'medium'"
-    @click="updateCurrentPage(pageCount)"
+    :size="currentPage === pageIndex ? 'default' : 'small'"
+    :color="currentPage === pageIndex ? 'dark' : 'medium'"
+    @click="updateCurrentPage(pageIndex)"
   >
-    {{ pageCount }}
+    {{ pageIndex }}
   </ion-button>
 
   <ion-button size="small" fill="clear" color="medium" @click="changePage(currentPage + 1)" :disabled="currentPage === totalPages">
@@ -57,13 +57,13 @@ function getDisplayedPageCounts() {
 }
 
 // Changes the current page to the specified page and emits an event to notify the parent component to fetch new items.
-function updateCurrentPage(pageCount: number) {
-  currentPage.value = pageCount;
+function updateCurrentPage(pageIndex: number) {
+  currentPage.value = pageIndex;
   const viewIndex = (currentPage.value - 1);
   emit('updatePageCount', viewIndex);
 }
 
-function changePage(pageCount: number) {
-  updateCurrentPage(pageCount);
+function changePage(pageIndex: number) {
+  updateCurrentPage(pageIndex);
 }
 </script>

--- a/src/components/DxpPagination.vue
+++ b/src/components/DxpPagination.vue
@@ -9,10 +9,9 @@
   <ion-button
     v-for="pageCount in getDisplayedPageCounts()"
     :key="pageCount"
-    size="small" 
     fill="clear"
+    :size="currentPage === pageCount ? 'default' : 'small'"
     :color="currentPage === pageCount ? 'dark' : 'medium'"
-    :class="{ 'selected-page': currentPage === pageCount }"
     @click="updateCurrentPage(pageCount)"
   >
     {{ pageCount }}
@@ -68,9 +67,3 @@ function changePage(pageCount: number) {
   updateCurrentPage(pageCount);
 }
 </script>
-
-<style scoped>
-.selected-page {
-  font-size: 15px;
-}
-</style>

--- a/src/components/DxpPagination.vue
+++ b/src/components/DxpPagination.vue
@@ -7,7 +7,7 @@
   </ion-button>
 
   <ion-button
-    v-for="pageIndex in getDisplayedPageIndexs()"
+    v-for="pageIndex in getDisplayedPageIndexes()"
     :key="pageIndex"
     fill="clear"
     :size="currentPage === pageIndex ? 'default' : 'small'"
@@ -46,7 +46,7 @@ const totalPages = computed(() => Math.ceil(props.totalItems / props.itemsPerPag
 const currentPage = ref(1);
 
 // Function to determine which page numbers to display based on the current page
-function getDisplayedPageIndexs() {
+function getDisplayedPageIndexes() {
   const pages = [];
   const startPage = Math.max(1, currentPage.value - 1);
   const endPage = Math.min(totalPages.value, currentPage.value + 1);

--- a/src/components/DxpPagination.vue
+++ b/src/components/DxpPagination.vue
@@ -1,13 +1,13 @@
 <template>
-  <ion-button size="small" fill="clear" color="medium" @click="changePage(1)" :disabled="currentPage === 1">
+  <ion-button size="small" fill="clear" color="medium" @click="updateCurrentPage(1)" :disabled="currentPage === 1">
     <ion-icon slot="icon-only" :icon="playSkipBackOutline" />
   </ion-button>
-  <ion-button size="small" fill="clear" color="medium" @click="changePage(currentPage - 1)" :disabled="currentPage === 1">
+  <ion-button size="small" fill="clear" color="medium" @click="updateCurrentPage(currentPage - 1)" :disabled="currentPage === 1">
     <ion-icon slot="icon-only" :icon="chevronBackOutline" />
   </ion-button>
 
   <ion-button
-    v-for="pageIndex in getDisplayedPageCounts()"
+    v-for="pageIndex in getDisplayedPageIndexs()"
     :key="pageIndex"
     fill="clear"
     :size="currentPage === pageIndex ? 'default' : 'small'"
@@ -17,10 +17,10 @@
     {{ pageIndex }}
   </ion-button>
 
-  <ion-button size="small" fill="clear" color="medium" @click="changePage(currentPage + 1)" :disabled="currentPage === totalPages">
+  <ion-button size="small" fill="clear" color="medium" @click="updateCurrentPage(currentPage + 1)" :disabled="currentPage === totalPages">
     <ion-icon slot="icon-only" :icon="chevronForwardOutline" />
   </ion-button>
-  <ion-button size="small" fill="clear" color="medium" @click="changePage(totalPages)" :disabled="currentPage === totalPages">
+  <ion-button size="small" fill="clear" color="medium" @click="updateCurrentPage(totalPages)" :disabled="currentPage === totalPages">
     <ion-icon slot="icon-only" :icon="playSkipForwardOutline" />
   </ion-button>
 </template>
@@ -40,13 +40,13 @@ const props = defineProps({
     required: true
   }
 });
-const emit = defineEmits(['updatePageCount']);
+const emit = defineEmits(['updatePageIndex']);
 
 const totalPages = computed(() => Math.ceil(props.totalItems / props.itemsPerPage))
 const currentPage = ref(1);
 
 // Function to determine which page numbers to display based on the current page
-function getDisplayedPageCounts() {
+function getDisplayedPageIndexs() {
   const pages = [];
   const startPage = Math.max(1, currentPage.value - 1);
   const endPage = Math.min(totalPages.value, currentPage.value + 1);
@@ -59,11 +59,10 @@ function getDisplayedPageCounts() {
 // Changes the current page to the specified page and emits an event to notify the parent component to fetch new items.
 function updateCurrentPage(pageIndex: number) {
   currentPage.value = pageIndex;
-  const viewIndex = (currentPage.value - 1);
-  emit('updatePageCount', viewIndex);
-}
-
-function changePage(pageIndex: number) {
-  updateCurrentPage(pageIndex);
+  // Subtracting 1 from the currentPage to calculate the viewIndex, as viewIndex starts from 0.
+  // This ensures that the first set of items is requested with viewIndex = 0 by default from the parent component.
+  // On subsequent page changes, the viewIndex emitted from here is adjusted accordingly to manage API calls efficiently.
+  const viewIndex = currentPage.value - 1;
+  emit('updatePageIndex', viewIndex);
 }
 </script>

--- a/src/components/DxpPagination.vue
+++ b/src/components/DxpPagination.vue
@@ -58,7 +58,7 @@ function getDisplayedPageCounts() {
 
 // Changes the current page to the specified page and emits an event to notify the parent component to fetch new items.
 function updateCurrentPage(pageCount: number) {
-  if (pageCount < 1 || pageCount > totalPages.value) {
+  if(pageCount < 1 || pageCount > totalPages.value) {
     return;
   }
   currentPage.value = pageCount;

--- a/src/components/DxpPagination.vue
+++ b/src/components/DxpPagination.vue
@@ -85,6 +85,6 @@ function goToLastPage() {
 
 <style scoped>
 .selected-page {
-  font-size: 16px;
+  font-size: 15px;
 }
 </style>

--- a/src/components/DxpPagination.vue
+++ b/src/components/DxpPagination.vue
@@ -1,0 +1,90 @@
+<template>
+  <ion-button size="small" fill="clear" color="medium" @click="goToFirstPage" :disabled="currentPage === 1">
+    <ion-icon slot="icon-only" :icon="playSkipBackOutline" />
+  </ion-button>
+  <ion-button size="small" fill="clear" color="medium" @click="goToPreviousPage" :disabled="currentPage === 1">
+    <ion-icon slot="icon-only" :icon="chevronBackOutline" />
+  </ion-button>
+
+  <ion-button
+    v-for="pageCount in getDisplayedPageCounts()"
+    :key="pageCount" size="small" fill="clear"
+    :color="currentPage === pageCount ? 'dark' : 'medium'"
+    :class="{ 'selected-page': currentPage === pageCount }"
+    @click="updateCurrentPage(pageCount)"
+  >
+    {{ pageCount }}
+  </ion-button>
+
+  <ion-button size="small" fill="clear" color="medium" @click="goToNextPage" :disabled="currentPage === totalPages">
+    <ion-icon slot="icon-only" :icon="chevronForwardOutline" />
+  </ion-button>
+  <ion-button size="small" fill="clear" color="medium" @click="goToLastPage" :disabled="currentPage === totalPages">
+    <ion-icon slot="icon-only" :icon="playSkipForwardOutline" />
+  </ion-button>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, defineProps, defineEmits } from 'vue';
+import { IonButton, IonIcon } from '@ionic/vue';
+import { playSkipBackOutline, chevronBackOutline, chevronForwardOutline, playSkipForwardOutline } from 'ionicons/icons';
+
+const props = defineProps({
+  itemsPerPage: {
+    type: Number,
+    required: true
+  },
+  totalItems: {
+    type: Number,
+    required: true
+  }
+});
+const emit = defineEmits(['updatePageCount']);
+
+const totalPages = computed(() => Math.ceil(props.totalItems / props.itemsPerPage))
+const currentPage = ref(1);
+
+// Function to determine which page numbers to display based on the current page
+function getDisplayedPageCounts() {
+  const pages = [];
+  const startPage = Math.max(1, currentPage.value - 1);
+  const endPage = Math.min(totalPages.value, startPage + 2);
+  
+  for(let i = startPage; i <= endPage; i++) {
+    pages.push(i);
+  }
+  return pages;
+}
+
+// Changes the current page to the specified page and emits an event to notify the parent component to fetch new items.
+function updateCurrentPage(pageCount: number) {
+  if (pageCount < 1 || pageCount > totalPages.value) {
+    return;
+  }
+  currentPage.value = pageCount;
+  const viewIndex = (currentPage.value - 1);
+  emit('updatePageCount', viewIndex);
+}
+
+function goToFirstPage() {
+  updateCurrentPage(1);
+}
+
+function goToPreviousPage() {
+  updateCurrentPage(currentPage.value - 1);
+}
+
+function goToNextPage() {
+  updateCurrentPage(currentPage.value + 1);
+}
+
+function goToLastPage() {
+  updateCurrentPage(totalPages.value);
+}
+</script>
+
+<style scoped>
+.selected-page {
+  font-size: 16px;
+}
+</style>

--- a/src/components/DxpPagination.vue
+++ b/src/components/DxpPagination.vue
@@ -1,14 +1,16 @@
 <template>
-  <ion-button size="small" fill="clear" color="medium" @click="goToFirstPage" :disabled="currentPage === 1">
+  <ion-button size="small" fill="clear" color="medium" @click="changePage(1)" :disabled="currentPage === 1">
     <ion-icon slot="icon-only" :icon="playSkipBackOutline" />
   </ion-button>
-  <ion-button size="small" fill="clear" color="medium" @click="goToPreviousPage" :disabled="currentPage === 1">
+  <ion-button size="small" fill="clear" color="medium" @click="changePage(currentPage - 1)" :disabled="currentPage === 1">
     <ion-icon slot="icon-only" :icon="chevronBackOutline" />
   </ion-button>
 
   <ion-button
     v-for="pageCount in getDisplayedPageCounts()"
-    :key="pageCount" size="small" fill="clear"
+    :key="pageCount"
+    size="small" 
+    fill="clear"
     :color="currentPage === pageCount ? 'dark' : 'medium'"
     :class="{ 'selected-page': currentPage === pageCount }"
     @click="updateCurrentPage(pageCount)"
@@ -16,10 +18,10 @@
     {{ pageCount }}
   </ion-button>
 
-  <ion-button size="small" fill="clear" color="medium" @click="goToNextPage" :disabled="currentPage === totalPages">
+  <ion-button size="small" fill="clear" color="medium" @click="changePage(currentPage + 1)" :disabled="currentPage === totalPages">
     <ion-icon slot="icon-only" :icon="chevronForwardOutline" />
   </ion-button>
-  <ion-button size="small" fill="clear" color="medium" @click="goToLastPage" :disabled="currentPage === totalPages">
+  <ion-button size="small" fill="clear" color="medium" @click="changePage(totalPages)" :disabled="currentPage === totalPages">
     <ion-icon slot="icon-only" :icon="playSkipForwardOutline" />
   </ion-button>
 </template>
@@ -48,8 +50,7 @@ const currentPage = ref(1);
 function getDisplayedPageCounts() {
   const pages = [];
   const startPage = Math.max(1, currentPage.value - 1);
-  const endPage = Math.min(totalPages.value, startPage + 2);
-  
+  const endPage = Math.min(totalPages.value, currentPage.value + 1);
   for(let i = startPage; i <= endPage; i++) {
     pages.push(i);
   }
@@ -58,28 +59,13 @@ function getDisplayedPageCounts() {
 
 // Changes the current page to the specified page and emits an event to notify the parent component to fetch new items.
 function updateCurrentPage(pageCount: number) {
-  if(pageCount < 1 || pageCount > totalPages.value) {
-    return;
-  }
   currentPage.value = pageCount;
   const viewIndex = (currentPage.value - 1);
   emit('updatePageCount', viewIndex);
 }
 
-function goToFirstPage() {
-  updateCurrentPage(1);
-}
-
-function goToPreviousPage() {
-  updateCurrentPage(currentPage.value - 1);
-}
-
-function goToNextPage() {
-  updateCurrentPage(currentPage.value + 1);
-}
-
-function goToLastPage() {
-  updateCurrentPage(totalPages.value);
+function changePage(pageCount: number) {
+  updateCurrentPage(pageCount);
 }
 </script>
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -22,6 +22,7 @@ export { default as DxpLanguageSwitcher } from './DxpLanguageSwitcher.vue';
 export { default as DxpLogin } from './DxpLogin.vue';
 export { default as DxpMenuFooterNavigation } from './DxpMenuFooterNavigation.vue';
 export { default as DxpOmsInstanceNavigator } from './DxpOmsInstanceNavigator.vue'
+export { default as DxpPagination } from './DxpPagination.vue'
 export { default as DxpProductIdentifier } from "./DxpProductIdentifier.vue";
 export { default as DxpProductStoreSelector } from "./DxpProductStoreSelector.vue"
 export { default as DxpShopifyImg } from './DxpShopifyImg.vue';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ declare var process: any;
 import { createPinia } from "pinia";
 import { useProductIdentificationStore } from "./store/productIdentification";
 import { useAuthStore } from "./store/auth";
-import { DxpAppVersionInfo, DxpFacilitySwitcher, DxpGitBookSearch, DxpImage, DxpLanguageSwitcher, DxpLogin, DxpMenuFooterNavigation, DxpOmsInstanceNavigator, DxpProductIdentifier, DxpProductStoreSelector, DxpShopifyImg, DxpTimeZoneSwitcher, DxpUserProfile } from "./components";
+import { DxpAppVersionInfo, DxpFacilitySwitcher, DxpGitBookSearch, DxpImage, DxpLanguageSwitcher, DxpLogin, DxpMenuFooterNavigation, DxpOmsInstanceNavigator, DxpPagination, DxpProductIdentifier, DxpProductStoreSelector, DxpShopifyImg, DxpTimeZoneSwitcher, DxpUserProfile } from "./components";
 import { goToOms, getProductIdentificationValue } from "./utils";
 import { initialiseFirebaseApp } from "./utils/firebase"
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
@@ -76,6 +76,7 @@ export let dxpComponents = {
     app.component('DxpLogin', DxpLogin)
     app.component('DxpMenuFooterNavigation', DxpMenuFooterNavigation)
     app.component('DxpOmsInstanceNavigator', DxpOmsInstanceNavigator)
+    app.component('DxpPagination', DxpPagination)
     app.component('DxpProductIdentifier', DxpProductIdentifier)
     app.component('DxpProductStoreSelector', DxpProductStoreSelector)
     app.component('DxpShopifyImg', DxpShopifyImg)
@@ -138,6 +139,7 @@ export {
   DxpLogin,
   DxpMenuFooterNavigation,
   DxpOmsInstanceNavigator,
+  DxpPagination,
   DxpProductIdentifier,
   DxpShopifyImg,
   DxpTimeZoneSwitcher,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#322 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Introduced a reusable pagination component for managing navigation across paginated data.  
- The component dynamically calculates and displays visible page numbers based on the current page and total pages, which are passed as props.  
- Emits an `updatePageCount` event with the updated page index to notify the parent component.  
- Provides controls for first, previous, next, and last page navigation, along with clear visual indicators for the currently selected page. 

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2025-01-16 18-46-47](https://github.com/user-attachments/assets/f6775846-2876-4fcf-9de2-81a305c43ba9)
![Screenshot from 2025-01-16 18-46-57](https://github.com/user-attachments/assets/fa66ed33-e349-4df3-8de6-b2c7505572df)
![Screenshot from 2025-01-16 18-46-43](https://github.com/user-attachments/assets/c0929272-4e7c-4e07-9cf7-ecd5182681a0)
### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [ ] Yes
- [x] No


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/dxp-components#contribution-guideline)