### PR TITLE
Fixed: When the modal is reopened, no option should appear pre-selected unless it was previously saved(#359)

### DIFF
--- a/src/components/DxpFacilitySwitcher.vue
+++ b/src/components/DxpFacilitySwitcher.vue
@@ -102,7 +102,7 @@ const facilityModal = ref()
 const queryString = ref('')
 const isLoading = ref(true);
 const filteredFacilities = ref([])
-const selectedFacilityId = ref(currentFacility.value.facilityId)
+const selectedFacilityId = ref('')
 
 const emit = defineEmits(["updateFacility"])
 
@@ -112,6 +112,7 @@ const closeModal = () => {
 
 function loadFacilities() {
   filteredFacilities.value = facilities.value;
+  selectedFacilityId.value = currentFacility.value.facilityId
   isLoading.value = false;
 }
 
@@ -149,6 +150,7 @@ async function updateFacility() {
 function clearSearch() {
   queryString.value = ''
   filteredFacilities.value = []
+  selectedFacilityId.value = ''
   isLoading.value = true
 }
 </script>


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#359 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Handled the case when, after opening the modal, the user selects any facility and closes the modal without saving, the ``selectedFacility`` gets updated. To fix this, I am emptying the ``selectedFacility`` on ``@didDismiss``.  
- Updating the ``selectedFacilityId`` ref on ``@didPresent`` to set the current facility correctly.  

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [ ] Yes
- [x] No


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/dxp-components#contribution-guideline)