### PR TITLE
Fixed: facility search not working when any of the facility has missing name

### DIFF
--- a/src/components/DxpFacilitySwitcher.vue
+++ b/src/components/DxpFacilitySwitcher.vue
@@ -121,8 +121,8 @@ const findFacility = () => {
   const searchedString = queryString.value.trim().toLowerCase();
   if(searchedString) {
     filteredFacilities.value = facilities.value.filter((facility: any) => 
-      facility.facilityName.toLowerCase().includes(searchedString) || 
-      facility.facilityId.toLowerCase().includes(searchedString)
+      facility.facilityName?.toLowerCase().includes(searchedString) ||
+      facility.facilityId?.toLowerCase().includes(searchedString)
     );
   } else {
     filteredFacilities.value = facilities.value;


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When searching for a facility, and if any of the facility has missing name, then the facility search does not completes, so added an optional chaining condition to complete the search even when missing facility name.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [ ] Yes
- [x] No


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/dxp-components#contribution-guideline)