### PR TITLE
Implemented: Added support for fetching all product stores (#363)

### DIFF
--- a/src/components/DxpMenuFooterNavigation.vue
+++ b/src/components/DxpMenuFooterNavigation.vue
@@ -8,15 +8,15 @@
         <ion-note :color="browserTimeZone === userAppState.userProfile?.userTimeZone ? '' : 'danger'" slot="end">{{ userAppState.userProfile?.userTimeZone }}</ion-note>
       </ion-item>
       <!-- showing product stores only when there are multiple options to choose from. -->
-      <ion-item v-if="userAppState.userProfile?.stores?.length > 2" lines="none">
+      <ion-item v-if="eComStores?.length > 2" lines="none">
         <!-- WHY EVENTS ($emit) IS USED WITH ION CHANGE: https://michaelnthiessen.com/pass-function-as-prop/ -->
-        <ion-select interface="popover" :value="userAppState.currentEComStore.productStoreId" @ionChange="$emit('updateEcomStore', $event)">
-          <ion-select-option v-for="store in userAppState.userProfile.stores" :key="store.productStoreId" :value="store.productStoreId">{{ store.storeName }}</ion-select-option>
+        <ion-select interface="popover" :value="currentEComStore.productStoreId" @ionChange="updateEComStore($event.target.value)">
+          <ion-select-option v-for="store in eComStores" :key="store.productStoreId" :value="store.productStoreId">{{ store.storeName }}</ion-select-option>
         </ion-select>
       </ion-item>
       <ion-item v-else lines="none">
         <ion-label class="ion-text-wrap">
-          {{ userAppState.currentEComStore.storeName }}
+          {{ currentEComStore.storeName }}
         </ion-label>
       </ion-item>
       <!-- similarly, showing shopify configs only when there are multiple options to choose from 
@@ -44,8 +44,12 @@ import { useUserStore } from 'src/store/user'
 
 const authStore = useAuthStore();
 const userStore = useUserStore()
+const emit = defineEmits(["updateEComStore"])
 const appState = appContext.config.globalProperties.$store;
-const instanceUrl = computed(() => authStore.getOms); 
+const instanceUrl = computed(() => authStore.getOms);
+const eComStores = computed(() => userStore.getProductStores); 
+const currentEComStore = computed(() => userStore.getCurrentEComStore);
+
 const userAppState = computed(() => ({ 
   userProfile: appState.getters['user/getUserProfile'],
   currentEComStore: userStore.getCurrentEComStore,
@@ -55,4 +59,10 @@ const userAppState = computed(() => ({
 
 // Accessing browser timeZone to check for timeZone diff of the app and browser
 const browserTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+async function updateEComStore(eComStoreId: any) {
+  const selectedProductStore = eComStores.value.find((store: any) => store.productStoreId == eComStoreId)
+  await userStore.setEComStorePreference(selectedProductStore)
+  emit('updateEComStore', selectedProductStore)
+}
 </script>

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,7 @@ export let dxpComponents = {
     facilityContext.getUserPreference = options.getUserPreference
      
     productStoreContext.getEComStoresByFacility = options.getEComStoresByFacility
+    productStoreContext.getEComStores = options.getEComStores
     productStoreContext.setUserPreference = options.setUserPreference
     productStoreContext.getUserPreference = options.getUserPreference
 

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -139,6 +139,17 @@ export const useUserStore = defineStore('user', {
       }
       return this.eComStores
     },
+    async getEComStores() {
+      const authStore = useAuthStore();
+    
+      try {
+        const response = await productStoreContext.getEComStores(authStore.getToken.value, authStore.getBaseUrl, 100);
+        this.eComStores = response;
+      } catch (error) {
+        console.error(error);
+      }
+      return this.eComStores
+    },
     async getEComStorePreference(userPrefTypeId: any) {
       const authStore = useAuthStore();
 


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#363 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added support for fetching all product stores, regardless of any parameters.  
- Dxp uses the `getEComStores` service from `oms-api`, passed from the application.  
- The `getEComStores` action updates Dxp's `eComStores` state in the product store selector.  
- Also updated the `DxpMenuFooterNavigation` component to use the `dxp-components` state for retrieving and updating product stores.  

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [ ] Yes
- [x] No


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/dxp-components#contribution-guideline)