### PR TITLE
Fixed: Empty Space Below Favourite Product Store Name on Login When No Shopify Shop is Linked (job-manager-725)

### DIFF
--- a/src/components/DxpMenuFooterNavigation.vue
+++ b/src/components/DxpMenuFooterNavigation.vue
@@ -22,7 +22,7 @@
       <!-- similarly, showing shopify configs only when there are multiple options to choose from 
       but if both product store and config have multiple options, then only option to choose
       product store will be visible -->
-      <div v-if="userAppState.shopifyConfigs?.length">
+      <template v-if="userAppState.shopifyConfigs?.length">
         <ion-item v-if="userAppState.shopifyConfigs?.length > 1 && userAppState.userProfile?.stores?.length < 3" lines="none">
           <ion-select interface="popover" :value="userAppState.currentShopifyConfig?.shopifyConfigId" @ionChange="$emit('updateShopifyConfig', $event)">
             <ion-select-option v-for="shopifyConfig in userAppState.shopifyConfigs" :key="shopifyConfig.shopifyConfigId" :value="shopifyConfig.shopifyConfigId">{{ shopifyConfig.name ? shopifyConfig.name : shopifyConfig.shopifyConfigName }}</ion-select-option>
@@ -33,7 +33,7 @@
             <p>{{ userAppState.currentShopifyConfig.name ? userAppState.currentShopifyConfig.name : userAppState.currentShopifyConfig.shopifyConfigName }}</p>
           </ion-label>
         </ion-item>
-      </div>
+      </template>
     </ion-toolbar>
   </ion-footer>
 </template>

--- a/src/components/DxpMenuFooterNavigation.vue
+++ b/src/components/DxpMenuFooterNavigation.vue
@@ -23,16 +23,16 @@
       but if both product store and config have multiple options, then only option to choose
       product store will be visible -->
       <div v-if="userAppState.shopifyConfigs?.length">
-      <ion-item v-if="userAppState.shopifyConfigs?.length > 1 && userAppState.userProfile?.stores?.length < 3" lines="none">
-        <ion-select interface="popover" :value="userAppState.currentShopifyConfig?.shopifyConfigId" @ionChange="$emit('updateShopifyConfig', $event)">
-          <ion-select-option v-for="shopifyConfig in userAppState.shopifyConfigs" :key="shopifyConfig.shopifyConfigId" :value="shopifyConfig.shopifyConfigId">{{ shopifyConfig.name ? shopifyConfig.name : shopifyConfig.shopifyConfigName }}</ion-select-option>
-        </ion-select>
-      </ion-item>
-      <ion-item v-else lines="none">
-        <ion-label class="ion-text-wrap">
-          <p>{{ userAppState.currentShopifyConfig.name ? userAppState.currentShopifyConfig.name : userAppState.currentShopifyConfig.shopifyConfigName }}</p>
-        </ion-label>
-      </ion-item>
+        <ion-item v-if="userAppState.shopifyConfigs?.length > 1 && userAppState.userProfile?.stores?.length < 3" lines="none">
+          <ion-select interface="popover" :value="userAppState.currentShopifyConfig?.shopifyConfigId" @ionChange="$emit('updateShopifyConfig', $event)">
+            <ion-select-option v-for="shopifyConfig in userAppState.shopifyConfigs" :key="shopifyConfig.shopifyConfigId" :value="shopifyConfig.shopifyConfigId">{{ shopifyConfig.name ? shopifyConfig.name : shopifyConfig.shopifyConfigName }}</ion-select-option>
+          </ion-select>
+        </ion-item>
+        <ion-item v-else lines="none">
+          <ion-label class="ion-text-wrap">
+            <p>{{ userAppState.currentShopifyConfig.name ? userAppState.currentShopifyConfig.name : userAppState.currentShopifyConfig.shopifyConfigName }}</p>
+          </ion-label>
+        </ion-item>
       </div>
     </ion-toolbar>
   </ion-footer>

--- a/src/components/DxpMenuFooterNavigation.vue
+++ b/src/components/DxpMenuFooterNavigation.vue
@@ -22,6 +22,7 @@
       <!-- similarly, showing shopify configs only when there are multiple options to choose from 
       but if both product store and config have multiple options, then only option to choose
       product store will be visible -->
+      <div v-if="userAppState.shopifyConfigs?.length">
       <ion-item v-if="userAppState.shopifyConfigs?.length > 1 && userAppState.userProfile?.stores?.length < 3" lines="none">
         <ion-select interface="popover" :value="userAppState.currentShopifyConfig?.shopifyConfigId" @ionChange="$emit('updateShopifyConfig', $event)">
           <ion-select-option v-for="shopifyConfig in userAppState.shopifyConfigs" :key="shopifyConfig.shopifyConfigId" :value="shopifyConfig.shopifyConfigId">{{ shopifyConfig.name ? shopifyConfig.name : shopifyConfig.shopifyConfigName }}</ion-select-option>
@@ -32,6 +33,7 @@
           <p>{{ userAppState.currentShopifyConfig.name ? userAppState.currentShopifyConfig.name : userAppState.currentShopifyConfig.shopifyConfigName }}</p>
         </ion-label>
       </ion-item>
+      </div>
     </ion-toolbar>
   </ion-footer>
 </template>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
https://github.com/hotwax/job-manager/issues/725
#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed: Empty Space Below Favourite Product Store Name on Login When No Shopify Shop is Linked (job-manager-725)

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [ ] Yes
- [x] No


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/dxp-components#contribution-guideline)