### PR TITLE
Improved: the code to Show spinner while fetching timezone to inform user that fetching in progress.(#301)

### DIFF
--- a/src/components/DxpTimeZoneSwitcher.vue
+++ b/src/components/DxpTimeZoneSwitcher.vue
@@ -127,7 +127,7 @@ const userProfile: any = computed(() => appState.getters['user/getUserProfile'])
 const timeZones = computed(() => userStore.getTimeZones)
 const currentTimeZoneId = computed(() => userStore.getCurrentTimeZone)
 
-const isLoading = ref(false);
+const isLoading = ref(true);
 const timeZoneModal = ref();
 const queryString = ref('');
 const filteredTimeZones = ref([])
@@ -212,5 +212,6 @@ function search() {
 function clearSearch() {
   queryString.value = ''
   filteredTimeZones.value = []
+  isLoading.value = true
 }
 </script>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
https://github.com/hotwax/preorder/issues/301
#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Now the spinner shows while fetching timezone to inform user that fetching is in progress.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/9e6c8ae8-38dd-4aef-901e-bb0913572ffb)


### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [ ] Yes
- [x] No


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/dxp-components#contribution-guideline)