### PR TITLE
Improved: Updated the product identifier selection (#350)

### DIFF
--- a/src/components/DxpProductIdentifier.vue
+++ b/src/components/DxpProductIdentifier.vue
@@ -13,12 +13,12 @@
 
     <ion-item :disabled="!appContext.hasPermission(appContext.Actions.APP_PRODUCT_IDENTIFIER_UPDATE)">
       <ion-select :label="$t('Primary')" interface="popover" :placeholder="'primary identifier'" :value="productIdentificationPref.primaryId" @ionChange="setProductIdentificationPref($event.detail.value, 'primaryId')">
-        <ion-select-option v-for="identification in productIdentificationOptions" :key="identification" :value="identification.goodIdentificationTypeId" >{{ identification.description ? identification.description : identification.goodIdentificationTypeId }}</ion-select-option>
+        <ion-select-option v-for="identification in productIdentificationOptions" :key="identification.goodIdentificationTypeId" :value="identification.goodIdentificationTypeId" >{{ identification.description ? identification.description : identification.goodIdentificationTypeId }}</ion-select-option>
       </ion-select>
     </ion-item>
     <ion-item lines="none" :disabled="!appContext.hasPermission(appContext.Actions.APP_PRODUCT_IDENTIFIER_UPDATE)">
       <ion-select :label="$t('Secondary')" interface="popover" :placeholder="'secondary identifier'" :value="productIdentificationPref.secondaryId" @ionChange="setProductIdentificationPref($event.detail.value, 'secondaryId')">
-        <ion-select-option v-for="identification in productIdentificationOptions" :key="identification" :value="identification.goodIdentificationTypeId" >{{ identification.description ? identification.description : identification.goodIdentificationTypeId }}</ion-select-option>
+        <ion-select-option v-for="identification in productIdentificationOptions" :key="identification.goodIdentificationTypeId" :value="identification.goodIdentificationTypeId" >{{ identification.description ? identification.description : identification.goodIdentificationTypeId }}</ion-select-option>
         <ion-select-option value="">{{ "None" }}</ion-select-option>
       </ion-select>
     </ion-item>

--- a/src/components/DxpProductIdentifier.vue
+++ b/src/components/DxpProductIdentifier.vue
@@ -13,12 +13,12 @@
 
     <ion-item :disabled="!appContext.hasPermission(appContext.Actions.APP_PRODUCT_IDENTIFIER_UPDATE)">
       <ion-select :label="$t('Primary')" interface="popover" :placeholder="'primary identifier'" :value="productIdentificationPref.primaryId" @ionChange="setProductIdentificationPref($event.detail.value, 'primaryId')">
-        <ion-select-option v-for="identification in productIdentificationOptions" :key="identification" :value="identification" >{{ identification }}</ion-select-option>
+        <ion-select-option v-for="identification in productIdentificationOptions" :key="identification" :value="identification.goodIdentificationTypeId" >{{ identification.description ? identification.description : identification.goodIdentificationTypeId }}</ion-select-option>
       </ion-select>
     </ion-item>
     <ion-item lines="none" :disabled="!appContext.hasPermission(appContext.Actions.APP_PRODUCT_IDENTIFIER_UPDATE)">
       <ion-select :label="$t('Secondary')" interface="popover" :placeholder="'secondary identifier'" :value="productIdentificationPref.secondaryId" @ionChange="setProductIdentificationPref($event.detail.value, 'secondaryId')">
-        <ion-select-option v-for="identification in productIdentificationOptions" :key="identification" :value="identification" >{{ identification }}</ion-select-option>
+        <ion-select-option v-for="identification in productIdentificationOptions" :key="identification" :value="identification.goodIdentificationTypeId" >{{ identification.description ? identification.description : identification.goodIdentificationTypeId }}</ion-select-option>
         <ion-select-option value="">{{ "None" }}</ion-select-option>
       </ion-select>
     </ion-item>

--- a/src/store/productIdentification.ts
+++ b/src/store/productIdentification.ts
@@ -49,12 +49,18 @@ export const useProductIdentificationStore = defineStore('productIdentification'
     },
     async prepareProductIdentifierOptions() {
       //static identifications 
-      const productIdentificationOptions = ["productId", "groupId", "groupName", "internalName", "parentProductName", "primaryProductCategoryName", "title"];
-      
+      const productIdentificationOptions = [
+        { goodIdentificationTypeId: "productId", description: "Product ID" },
+        { goodIdentificationTypeId: "groupId", description: "Group ID" },
+        { goodIdentificationTypeId: "groupName", description: "Group Name" },
+        { goodIdentificationTypeId: "internalName", description: "Internal Name" },
+        { goodIdentificationTypeId: "parentProductName", description: "Parent Product Name" },
+        { goodIdentificationTypeId: "primaryProductCategoryName", description: "Primary Product Category Name" },
+        { goodIdentificationTypeId: "title", description: "Title" }
+      ]
       //good identification types
       const fetchedGoodIdentificationTypes = await productIdentificationContext.fetchGoodIdentificationTypes("HC_GOOD_ID_TYPE");
-      const fetchedGoodIdentificationOptions = fetchedGoodIdentificationTypes?.map((fetchedGoodIdentificationType: any) => fetchedGoodIdentificationType.goodIdentificationTypeId) || [];
-  
+      const fetchedGoodIdentificationOptions = fetchedGoodIdentificationTypes || []
       // Merge the arrays and remove duplicates
       this.productIdentificationOptions = Array.from(new Set([...productIdentificationOptions, ...fetchedGoodIdentificationOptions])).sort();
       this.goodIdentificationOptions = fetchedGoodIdentificationOptions


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#350 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added support to show the description of the good identification type instead of the typeId

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [x] Yes
- [ ] No

- Previously, the getters of the product identification state returned only the `goodIdentificationTypeId`, and we directly displayed the `typeId` in our application. After this change, the getter will return an array of objects, each containing the `goodIdentificationTypeId` along with its description.
- So currently, wherever we are using this to display the identification list using a loop, instead of directly using the looped value, use dot notation (`.`) to access the properties, i.e., `goodIdentificationTypeId` and `description`.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/dxp-components#contribution-guideline)