### PR TITLE
Improved: "Go to OMS" button will be hidden in standalone mode and will be permission-driven (#376)

### DIFF
--- a/src/components/DxpOmsInstanceNavigator.vue
+++ b/src/components/DxpOmsInstanceNavigator.vue
@@ -11,7 +11,7 @@
     <ion-card-content>
       {{ $t('This is the name of the OMS you are connected to right now. Make sure that you are connected to the right instance before proceeding.') }}
     </ion-card-content>
-    <ion-button @click="goToOms(token.value, oms)" fill="clear" :disabled="!appContext.hasPermission(appContext.Actions.APP_COMMERCE_VIEW)">
+    <ion-button :class="{ 'hide-in-standalone': !appContext.hasPermission(appContext.Actions.APP_PWA_STANDALONE_ACCESS) }" @click="goToOms(token.value, oms)" fill="clear" :disabled="!appContext.hasPermission(appContext.Actions.APP_COMMERCE_VIEW)">
       {{ $t('Go to OMS') }}
       <ion-icon slot="end" :icon="openOutline" />
     </ion-button>
@@ -39,3 +39,12 @@ const authStore = useAuthStore();
 const token = computed(() => authStore.getToken)
 const oms = computed(() => authStore.getOms)
 </script>
+
+<style scoped>
+/* Added conditional hiding in standalone mode that respects user permissions */
+@media (display-mode: standalone) {
+  .hide-in-standalone {
+    display: none;
+  }
+}
+</style>


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#376 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- "Go to OMS" button will be hidden in standalone mode and will be permission-driven.
- Unless user have the required permission in standalone mode, the button will be hidden.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [x] Yes
- [ ] Non

Applications using the `DxpOmsInstanceNavigator` component must have the required permission (`APP_PWA_STANDALONE_ACCESS`) to access the 'Go to OMS' button in the home screen app (standalone mode).

Let me know if you want a more concise or technical version!
### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/dxp-components#contribution-guideline)