### PR TITLE
Added shop and host in auth state and updated get app login util method

### DIFF
--- a/src/components/DxpLogin.vue
+++ b/src/components/DxpLogin.vue
@@ -55,13 +55,13 @@ onMounted(async () => {
     return
   }
 
-  const { token, oms, expirationTime, omsRedirectionUrl ,isEmbedded} = route.query
+  const { token, oms, expirationTime, omsRedirectionUrl, isEmbedded, shop, host} = route.query
   // Update the flag in auth, since the store is updated app login url will be embedded luanchpad's url.
   const isEmbeddedFlag = isEmbedded === 'true'
-  await handleUserFlow(token, oms, expirationTime, omsRedirectionUrl, isEmbeddedFlag)
+  await handleUserFlow(token, oms, expirationTime, omsRedirectionUrl, isEmbeddedFlag, shop, host)
 });
 
-async function handleUserFlow(token: string, oms: string, expirationTime: string, omsRedirectionUrl = "", isEmbedded: boolean) {
+async function handleUserFlow(token: string, oms: string, expirationTime: string, omsRedirectionUrl = "", isEmbedded: boolean, shop: string, host: string) {
   // fetch the current config for the user
   const appConfig = loginContext.getConfig()
 
@@ -80,6 +80,8 @@ async function handleUserFlow(token: string, oms: string, expirationTime: string
     // The launchpad urls are defined the env file in each PW App. 
     // Setting this flag here because it is needed to identify the launchpad's URL, this will updated in this function later.
     authStore.isEmbedded = isEmbedded
+    authStore.shop = shop? shop: undefined
+    authStore.host = host? host: undefined
     const appLoginUrl = getAppLoginUrl()
     if (isEmbedded) {
       window.location.replace(appLoginUrl)
@@ -94,7 +96,9 @@ async function handleUserFlow(token: string, oms: string, expirationTime: string
   authStore.$patch({
     token: { value: token, expiration: expirationTime as any },
     oms,
-    isEmbedded
+    isEmbedded,
+    shop: shop as any,
+    host: host as any
   })
 
   context.loader.present('Logging in')

--- a/src/components/DxpLogin.vue
+++ b/src/components/DxpLogin.vue
@@ -80,8 +80,8 @@ async function handleUserFlow(token: string, oms: string, expirationTime: string
     // The launchpad urls are defined the env file in each PW App. 
     // Setting this flag here because it is needed to identify the launchpad's URL, this will updated in this function later.
     authStore.isEmbedded = isEmbedded
-    authStore.shop = shop? shop: undefined
-    authStore.host = host? host: undefined
+    authStore.shop = shop
+    authStore.host = host
     const appLoginUrl = getAppLoginUrl()
     if (isEmbedded) {
       window.location.replace(appLoginUrl)
@@ -104,7 +104,7 @@ async function handleUserFlow(token: string, oms: string, expirationTime: string
   context.loader.present('Logging in')
   try {
     // redirect route will be returned for certain cases
-    const redirectRoute = await context.login({ token, oms, omsRedirectionUrl, isEmbedded})
+    const redirectRoute = await context.login({ token, oms, omsRedirectionUrl})
 
     const userStore = useUserStore()
     // to access baseUrl as we store only OMS in DXP

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -10,7 +10,9 @@ export const useAuthStore = defineStore('userAuth', {
         expiration: undefined
       },
       oms: '',
-      isEmbedded: false
+      isEmbedded: false,
+      shop: undefined,
+      host: undefined,
     }
   },
   getters: {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -58,7 +58,7 @@ const getCurrentTime = (zone: string, format = 't ZZZZ') => {
 const getAppLoginUrl = () => {
   const authStore = useAuthStore();
   if (authStore.isEmbedded) {
-    return process.env.VUE_APP_EMBEDDED_LAUNCHPAD_URL
+    return `${process.env.VUE_APP_EMBEDDED_LAUNCHPAD_URL}/?shop=${authStore.shop}&host=${authStore.host}`
   } else {
     return process.env.VUE_APP_LOGIN_URL
   }


### PR DESCRIPTION
#408 

When redirecting to the embedded launchpad, we redirect successfully but without the shop and host becase the initial context when the app was loaded from the Admin or POS is lost when we redirected to our PW App. It it seen that if we pass only the shop and host with the URL then the the app is opened in Admin with proper context.

To verify the same behaviour in the POS, we've to test.

This PR is for POC in Shopify POS.