### PR TITLE
Hide Commerce link Shopify Embedded App Users

### DIFF
--- a/src/components/DxpOmsInstanceNavigator.vue
+++ b/src/components/DxpOmsInstanceNavigator.vue
@@ -11,7 +11,7 @@
     <ion-card-content>
       {{ $t('This is the name of the OMS you are connected to right now. Make sure that you are connected to the right instance before proceeding.') }}
     </ion-card-content>
-    <ion-button @click="goToOms(token.value, oms)" fill="clear" :disabled="!appContext.hasPermission(appContext.Actions.APP_COMMERCE_VIEW)">
+    <ion-button v-if="!authStore.isEmbedded" @click="goToOms(token.value, oms)" fill="clear" :disabled="!appContext.hasPermission(appContext.Actions.APP_COMMERCE_VIEW)">
       {{ $t('Go to OMS') }}
       <ion-icon slot="end" :icon="openOutline" />
     </ion-button>


### PR DESCRIPTION
Hide commerce link if the auth state has the isEmbedded flag as true meaning the App is running as embedded.