### PR TITLE
Improved: image component to use the oms url as default resource url

### DIFF
--- a/src/components/DxpImage.vue
+++ b/src/components/DxpImage.vue
@@ -11,6 +11,8 @@ declare let process: any;
 const props = defineProps(['src']);
 let imageUrl = ref(context.defaultImgUrl);
 
+const oms = useAuthStore().getOms;
+
 const setImageUrl = () => {
   if (props.src) {
     if (props.src.startsWith('http')) {
@@ -24,12 +26,10 @@ const setImageUrl = () => {
       // Assign directly in case of assets or if image starts with /img/ (when url start with /img/ then the img is the local asset url of the app)
       imageUrl.value = props.src;
     } else {
-
-      const oms = useAuthStore().getOms;
       const resourceUrl = oms.startsWith('http') ? oms.replace("/api", "") : `https://${oms}.hotwax.io/`
       // Image is from resource server, hence append to base resource url, check for existence and assign
       const newImageUrl = resourceUrl.concat(props.src)
-      checkIfImageExists(imageUrl).then(() => {
+      checkIfImageExists(newImageUrl).then(() => {
         imageUrl.value = newImageUrl;
       }).catch(() => {
         console.error("Image doesn't exist");


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Removed usage of VUE_APP_RESOURCE_URL env as its maintained anymore and instead using the oms url to fetch the image

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [ ] Yes
- [x] No


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/dxp-components#contribution-guideline)